### PR TITLE
rtl ignore to tabs alignment

### DIFF
--- a/src/components/Tabs/Tabs.st.css
+++ b/src/components/Tabs/Tabs.st.css
@@ -32,15 +32,19 @@
 }
 
 .root:alignment(left) nav {
+    /*rtl:remove*/
     justify-content: flex-start;
+    /*rtl:raw:
+      justify-content: flex-end;
+    */
 }
 
 .root:alignment(right) nav {
+    /*rtl:remove*/
     justify-content: flex-end;
-}
-
-.root:alignment(center) nav {
-    justify-content: center;
+    /*rtl:raw:
+      justify-content: flex-start;
+    */
 }
 
 .tab {


### PR DESCRIPTION
Hi Shlomi,
We want to disable the alignment if we are in rtl , since the alignment is controlled by the user from settings.