### PR TITLE
Tabs Menu - Change the divider color opacity

### DIFF
--- a/src/components/Tabs/Tabs.st.css
+++ b/src/components/Tabs/Tabs.st.css
@@ -61,7 +61,7 @@
 .root:skin(fullUnderline),
 .root:skin(fitUnderline) .tab{
     border-bottom: 1px solid;
-    border-bottom-color: wixApply(opacity, wixApply(color, wixApply(fallback, value(IndicatorColor), value(defaultIndicatorColor))), 0.2);
+    border-bottom-color: wixApply(color, wixApply(fallback, value(IndicatorColor), wixApply(opacity, wixApply(color, value(defaultIndicatorColor)), 0.2)));
 }
 
 .root:skin(clear) .activeTab,


### PR DESCRIPTION
Hi Shlomi/Jonathan,
We need to apply opacity only on the default border color. I made the changes, can you please check ?