### PR TITLE
fix braking change from wix-style-processor

### DIFF
--- a/src/components/Card/mixins.st.css
+++ b/src/components/Card/mixins.st.css
@@ -17,5 +17,5 @@
 }
 
 .withDynamicPadding {
-    padding: wixApply(calc, wixApply(string, -), value(PaddingSize), value(BorderWidth));
+    padding: wixApply(calculate, wixApply(string, -), value(PaddingSize), value(BorderWidth));
 }


### PR DESCRIPTION
there's a breaking change in wix-style-processor with renaming the calc function to calculator