### PR TITLE
fix StripCard border color always apply opacity on TPA overrides

### DIFF
--- a/src/components/StripCard/StripCard.st.css
+++ b/src/components/StripCard/StripCard.st.css
@@ -34,7 +34,7 @@
 :vars {
     cardBGColor: wixApply(color, wixApply(fallback, value(MainBGColor), value(DefaultCardBG)));
     borderWidth: wixApply(unit, wixApply(fallback, wixApply(zeroAsTrue, value(MainBorderWidth)), wixApply(zeroAsTrue, value(DefaultBorderWidth))), px);
-    borderColor: wixApply(opacity, wixApply(color, wixApply(fallback, value(MainBorderColor), value(DefaultBorderColor))), 0.2);
+    borderColor: wixApply(color, wixApply(fallback, value(MainBorderColor), wixApply(opacity, wixApply(color, value(DefaultBorderColor)), 0.2)));
     mediaBGColor: wixApply(color, wixApply(fallback, value(MainMediaColor), wixApply(opacity, wixApply(color, value(DefaultMediaBG)), 0.2)));
 }
 


### PR DESCRIPTION
should not break eyes, default border width is 0