### PR TITLE
fix(pagination): do not use "input" mode for mobile layout

### DIFF
--- a/src/components/Pagination/Pagination.spec.tsx
+++ b/src/components/Pagination/Pagination.spec.tsx
@@ -19,7 +19,7 @@ describe('Pagination', () => {
     expect(driver.exists()).toBe(true);
   });
 
-  it('should use mobile design', async () => {
+  it.skip('should use mobile design', async () => {
     const driver = createDriver(
       TPAComponentsWrapper({ mobile: true })(<Pagination totalPages={10} />),
     );
@@ -49,7 +49,7 @@ describe('Pagination', () => {
     expect(driver.getPageInput()).toBeNull();
   });
 
-  it('Should use core "input" mode when is mobile', async () => {
+  it.skip('Should use core "input" mode when is mobile', async () => {
     const driver = createDriver(
       TPAComponentsWrapper({ mobile: true })(<Pagination totalPages={10} />),
     );

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -30,8 +30,6 @@ export const Pagination: React.FunctionComponent<PaginationProps> = props => {
             lastLabel={DoubleChevronRight}
             rtl={rtl}
             showFirstLastNavButtons={props.totalPages > props.maxPagesToShow}
-            paginationMode={mobileView ? 'input' : 'pages'}
-            showInputModeTotalPages={mobileView}
             {...props}
           />
         );


### PR DESCRIPTION
Using `input` mode for mobile pagination component leads to unexpected behaviour, we need to disable this functionality for now and restore it once https://github.com/wix/wix-ui/pull/1369 finished. 

Before it's done mobile and desktop design of `Pagination` component should look identically. 