### PR TITLE
fix wix-style-processor hmr problems in storybook

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,30 +1,17 @@
 import {configure, addParameters} from '@storybook/react';
 import styleProcessor from 'wix-style-processor';
-import domService from 'wix-style-processor/dist/es/src/domService';
-
-const fixedDomService = {
-  ...domService,
-  overrideStyle: (tag, css) => {
-    const result = domService.overrideStyle(tag, css);
-    delete tag.originalTemplate;
-    return result;
-  },
-};
-
-let isRendered = false;
 
 function loadStories() {
   require('../stories');
   require('../mocks');
   require('./stories.scss');
-  if (!isRendered) {
-    styleProcessor.init({}, fixedDomService);
-    isRendered = true;
-  } else {
-    setTimeout(() => {
-      styleProcessor.update();
-    });
-  }
+  setTimeout(() => {
+    styleProcessor.init();
+  });
+}
+
+function configureStorybook () {
+  configure(loadStories, module);
 }
 
 addParameters({
@@ -35,10 +22,10 @@ addParameters({
   }
 });
 
-configure(loadStories, module);
+configureStorybook();
 
 if (module.hot) {
   module.hot.accept('../stories', () => {
-    configure(loadStories, module);
+    configureStorybook();
   });
 }

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,9 +1,30 @@
 import {configure, addParameters} from '@storybook/react';
+import styleProcessor from 'wix-style-processor';
+import domService from 'wix-style-processor/dist/es/src/domService';
+
+const fixedDomService = {
+  ...domService,
+  overrideStyle: (tag, css) => {
+    const result = domService.overrideStyle(tag, css);
+    delete tag.originalTemplate;
+    return result;
+  },
+};
+
+let isRendered = false;
 
 function loadStories() {
   require('../stories');
   require('../mocks');
   require('./stories.scss');
+  if (!isRendered) {
+    styleProcessor.init({}, fixedDomService);
+    isRendered = true;
+  } else {
+    setTimeout(() => {
+      styleProcessor.update();
+    });
+  }
 }
 
 addParameters({
@@ -15,3 +36,9 @@ addParameters({
 });
 
 configure(loadStories, module);
+
+if (module.hot) {
+  module.hot.accept('../stories', () => {
+    configure(loadStories, module);
+  });
+}

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -1,7 +1,3 @@
-import styleProcessor from 'wix-style-processor';
-
-styleProcessor.init();
-
 require('../src/components/Autocomplete/docs/index.story');
 require('../src/components/Button/docs/index.story');
 require('../src/components/StatesButton/docs/index.story');

--- a/webpack.config.storybook.js
+++ b/webpack.config.storybook.js
@@ -10,11 +10,10 @@ const autoprefixProcessor = postcss([autoprefixer]);
 
 //TODO - this should be configured inside yoshi
 function reconfigureStylable(config) {
-    const stylableSeparateCss = project.enhancedTpaStyle;
     const stylablePlugin = new StylableWebpackPlugin({
-        outputCSS: stylableSeparateCss,
+        outputCSS: false,
         filename: '[name].stylable.bundle.css',
-        includeCSSInJS: !stylableSeparateCss,
+        includeCSSInJS: true,
         optimize: { classNameOptimizations: false, shortNamespaces: false },
         runtimeMode: 'shared',
         globalRuntimeId: '__stylable_yoshi__',


### PR DESCRIPTION
hack wix-style-processor to fix hmr problems in storybook when changing st.css files

Problem is happening because of this line:
https://github.com/wix/wix-style-processor/blob/cf38dd80ba3e0b142b25b4313a42d6a7f9baede2/src/styleUpdater.ts#L25

Which causes `wix-style-processor` to ignore changes to style tags

plus

I had to add a timeout to let `wix-style-processor` run after hmr runs