### PR TITLE
tabs - fix :before selector

### DIFF
--- a/src/components/Tabs/Tabs.st.css
+++ b/src/components/Tabs/Tabs.st.css
@@ -49,7 +49,7 @@
     line-height: 1.5;
 }
 
-.root:before {
+.root::before {
     content: '\00a0';
 }
 


### PR DESCRIPTION
fixing critical error with tabs before pseudo element