### PR TITLE
Fix icon import from `wix-ui-icons-common`

### DIFF
--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import classnames from 'classnames';
 import ReactResizeDetector from 'react-resize-detector';
-import { ChevronLeft, ChevronRight } from 'wix-ui-icons-common';
+import ChevronLeft from 'wix-ui-icons-common/ChevronLeft';
+import ChevronRight from 'wix-ui-icons-common/ChevronRight';
 import { TPAComponentsConsumer } from '../TPAComponentsConfig';
 import { TabItem } from './Tab';
 import { ScrollableTabs } from './ScrollableTabs';


### PR DESCRIPTION
Currently half of our bundle size is `wix-ui-icons-common`.
Its because of way if icons import in `Tabs` component.

This PR use direct icons import to prevent bundling all of them.

![image](https://user-images.githubusercontent.com/2445828/63508343-7371c680-c4e2-11e9-9298-471505016e32.png)
