### PR TITLE
chore(*): use direct path to wix-ui-core drivers

### DIFF
--- a/src/components/Autocomplete/Autocomplete.driver.ts
+++ b/src/components/Autocomplete/Autocomplete.driver.ts
@@ -1,4 +1,4 @@
-import { autocompleteDriverFactory as coreAutocompleteDriverFactory } from 'wix-ui-core/drivers/vanilla';
+import { autocompleteDriverFactory as coreAutocompleteDriverFactory } from 'wix-ui-core/dist/src/components/autocomplete/Autocomplete.driver';
 import { errorMessageWrapperDriverFactory } from '../ErrorMessageWrapper/ErrorMessageWrapper.driver';
 
 export const autocompleteDriverFactory = ({ element, eventTrigger }) => {

--- a/src/components/Autocomplete/Autocomplete.protractor.driver.ts
+++ b/src/components/Autocomplete/Autocomplete.protractor.driver.ts
@@ -1,4 +1,4 @@
 export {
   autocompleteDriverFactory,
   AutocompleteDriver,
-} from 'wix-ui-core/drivers/protractor';
+} from 'wix-ui-core/dist/src/components/autocomplete/Autocomplete.protractor.driver';

--- a/src/components/Button/Button.driver.ts
+++ b/src/components/Button/Button.driver.ts
@@ -1,7 +1,7 @@
 import {
   ButtonNextDriver,
   buttonNextDriverFactory,
-} from 'wix-ui-core/drivers/unidriver';
+} from 'wix-ui-core/dist/src/components/button-next/button-next.uni.driver';
 import { StylableUnidriverUtil, UniDriver } from 'wix-ui-test-utils/unidriver';
 import style from './Button.st.css';
 

--- a/src/components/IconToggle/IconToggle.driver.ts
+++ b/src/components/IconToggle/IconToggle.driver.ts
@@ -1,4 +1,4 @@
-import { checkboxDriverFactory as coreCheckboxDriverFactory } from 'wix-ui-core/drivers/vanilla';
+import { checkboxDriverFactory as coreCheckboxDriverFactory } from 'wix-ui-core/dist/src/components/checkbox/Checkbox.driver';
 import { StylableDOMUtil } from '@stylable/dom-test-kit';
 import style from './IconToggle.st.css';
 

--- a/src/components/IconToggle/IconToggle.protractor.driver.ts
+++ b/src/components/IconToggle/IconToggle.protractor.driver.ts
@@ -1,4 +1,4 @@
 export {
   checkboxDriverFactory as iconToggleDriverFactory,
   CheckboxDriver as IconToggleDriver,
-} from 'wix-ui-core/drivers/protractor';
+} from 'wix-ui-core/dist/src/components/checkbox/Checkbox.protractor.driver';

--- a/src/components/Input/Input.driver.ts
+++ b/src/components/Input/Input.driver.ts
@@ -1,4 +1,4 @@
-import { inputDriverFactory as coreDriver } from 'wix-ui-core/drivers/vanilla';
+import { inputDriverFactory as coreDriver } from 'wix-ui-core/dist/src/components/input/Input.driver';
 import { StylableDOMUtil } from '@stylable/dom-test-kit';
 import style from './Input.st.css';
 

--- a/src/components/Input/Input.protractor.driver.ts
+++ b/src/components/Input/Input.protractor.driver.ts
@@ -1,4 +1,4 @@
 export {
   inputDriverFactory,
   InputDriver,
-} from 'wix-ui-core/drivers/protractor';
+} from 'wix-ui-core/dist/src/components/input/Input.protractor.driver';

--- a/src/components/Pagination/Pagination.driver.ts
+++ b/src/components/Pagination/Pagination.driver.ts
@@ -1,7 +1,7 @@
 import { StylableDOMUtil } from '@stylable/dom-test-kit';
 import { Simulate } from 'react-dom/test-utils';
 
-import { paginationDriverFactory as corePaginationDriverFactory } from 'wix-ui-core/drivers/vanilla';
+import { paginationDriverFactory as corePaginationDriverFactory } from 'wix-ui-core/dist/src/components/pagination/Pagination.driver';
 
 import style from './Pagination.st.css';
 

--- a/src/components/Pagination/Pagination.protractor.driver.ts
+++ b/src/components/Pagination/Pagination.protractor.driver.ts
@@ -1,4 +1,4 @@
 export {
   paginationDriverFactory,
   PaginationDriver,
-} from 'wix-ui-core/drivers/protractor';
+} from 'wix-ui-core/dist/src/components/pagination/Pagination.protractor.driver';

--- a/src/components/StatesButton/StatesButton.driver.ts
+++ b/src/components/StatesButton/StatesButton.driver.ts
@@ -1,7 +1,7 @@
 import {
   ButtonNextDriver,
   buttonNextDriverFactory,
-} from 'wix-ui-core/drivers/unidriver';
+} from 'wix-ui-core/dist/src/components/button-next/button-next.uni.driver';
 import { StylableUnidriverUtil, UniDriver } from 'wix-ui-test-utils/unidriver';
 import style from './StatesButton.st.css';
 

--- a/src/components/TextButton/TextButton.driver.ts
+++ b/src/components/TextButton/TextButton.driver.ts
@@ -1,7 +1,7 @@
 import {
   ButtonNextDriver,
   buttonNextDriverFactory,
-} from 'wix-ui-core/drivers/unidriver';
+} from 'wix-ui-core/dist/src/components/button-next/button-next.uni.driver';
 import { StylableUnidriverUtil, UniDriver } from 'wix-ui-test-utils/unidriver';
 import style from './TextButton.st.css';
 import { TEXT_BUTTON_PRIORITY } from './TextButton';

--- a/src/components/TextField/TextField.driver.ts
+++ b/src/components/TextField/TextField.driver.ts
@@ -1,4 +1,4 @@
-import { inputDriverFactory as coreDriver } from 'wix-ui-core/drivers/vanilla';
+import { inputDriverFactory as coreDriver } from 'wix-ui-core/dist/src/components/input/Input.driver';
 import { EMPTY, ERROR, ERROR_MESSAGE, SUCCESS, THEME } from './dataKeys';
 
 export const textFieldDriverFactory = ({ element, eventTrigger }) => {

--- a/src/components/TextField/TextField.protractor.driver.ts
+++ b/src/components/TextField/TextField.protractor.driver.ts
@@ -1,7 +1,7 @@
 import {
   inputDriverFactory,
   InputDriver,
-} from 'wix-ui-core/drivers/protractor';
+} from 'wix-ui-core/dist/src/components/input/Input.protractor.driver';
 
 export interface TextFieldDriver extends InputDriver {
   hover();

--- a/src/components/Tooltip/Tooltip.driver.ts
+++ b/src/components/Tooltip/Tooltip.driver.ts
@@ -1,4 +1,4 @@
-import { tooltipDriverFactory as coreTooltipDriverFactory } from 'wix-ui-core/drivers/vanilla';
+import { tooltipDriverFactory as coreTooltipDriverFactory } from 'wix-ui-core/dist/src/components/tooltip/Tooltip.driver';
 
 export const tooltipDriverFactory = component => {
   const tooltipDriver = coreTooltipDriverFactory(component);

--- a/src/components/Tooltip/Tooltip.protractor.driver.ts
+++ b/src/components/Tooltip/Tooltip.protractor.driver.ts
@@ -1,7 +1,7 @@
 import {
   tooltipDriverFactory as coreDriver,
   TooltipDriver as coreTooltipDriver,
-} from 'wix-ui-core/drivers/protractor';
+} from 'wix-ui-core/dist/src/components/tooltip/Tooltip.protractor.driver';
 
 export interface TooltipProtractorDriver extends coreTooltipDriver {}
 


### PR DESCRIPTION
as I described privately, this should is neccessary now for testkit
documentation to work.

it should be a temporary change until [this template](https://github.com/wix/wix-ui/blob/master/packages/wix-ui-core/.wuf/testkits/vanilla.template.ejs#L15) is doing better work than `...require()`
