### PR TITLE
docs(testkit/*): add testkit import examples

### DIFF
--- a/webpack.config.storybook.js
+++ b/webpack.config.storybook.js
@@ -36,6 +36,9 @@ function reconfigureStylable(config) {
     return config;
 }
 
+const makeTestkitTemplate = platform =>
+  `import { <%= utils.toCamel(component.displayName) %>TestkitFactory } from 'wix-ui-tpa/dist/src/testkit${platform}';`;
+
 module.exports = ({config}) => {
     const newConfig = reconfigureStylable(wixStorybookConfig(config));
 
@@ -56,7 +59,21 @@ module.exports = ({config}) => {
                         moduleName: 'wix-ui-tpa',
                         repoBaseURL: 'https://github.com/wix/wix-ui-tpa/tree/master/src/components/',
                         importFormat: "import {%componentName} from '%moduleName/%componentName'",
-                        issueURL: "https://github.com/wix/wix-ui-tpa/issues/new"
+                        issueURL: "https://github.com/wix/wix-ui-tpa/issues/new",
+                        testkits: {
+                          vanilla: {
+                            template: makeTestkitTemplate(''),
+                          },
+                          enzyme: {
+                            template: makeTestkitTemplate('/enzyme'),
+                          },
+                          puppeteer: {
+                            template: makeTestkitTemplate('/puppeteer'),
+                          },
+                          protractor: {
+                            template: makeTestkitTemplate('/protractor'),
+                          }
+                        }
                     }
                 }
             })


### PR DESCRIPTION
This addition will allow testkit tabs to display appropriate import example

closes #148 

![2019-09-19-112113_screenshot](https://user-images.githubusercontent.com/4284659/65226722-072db700-dad0-11e9-8cd4-77a81cbcd158.png)
