### PR TITLE
Fix Avatar when no src was provided

### DIFF
--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -45,7 +45,7 @@ export class Avatar extends React.Component<AvatarProps> {
     return (
       <CoreAvatar
         {...styles('root', { size }, rest)}
-        imgProps={{ src }}
+        imgProps={src ? { src } : undefined}
         placeholder={
           <Anonymous
             height={Avatar.dimmentionBySize[size]}


### PR DESCRIPTION
@jonathanadler
Hey,
it's a fix for Avatar when no image src is provided.
If anything is passed to imgProps in wix-ui-core's Avatar, even if src is undefined, it tries to load an image with src '/undefined', producing a bad request.

![Screen Shot 2019-10-04 at 3 51 11 PM](https://user-images.githubusercontent.com/22763470/66208851-cda79f00-e6be-11e9-84df-29cfb85483e7.png)
