### PR TITLE
fix (grid-component) compatibility in edge and firefox

### DIFF
--- a/src/components/Card/Card.st.css
+++ b/src/components/Card/Card.st.css
@@ -64,7 +64,7 @@
 .root:stacked:invertInfoPosition:mobile,
 .root:stacked:mobile,
 .root:stacked {
-    flex-direction: column;
+    display: block;
 }
 
 .root:invertInfoPosition {

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -165,7 +165,7 @@ export class Grid extends React.PureComponent<GridProps> {
                 className={styles.listWrapper}
                 style={{
                   gridTemplateColumns,
-                  gap: `${rowGapInPixels} ${columnGapInPixels}`,
+                  gridGap: `${rowGapInPixels} ${columnGapInPixels}`,
                 }}
                 {...this.getContainerDataAttributes({
                   itemMaxWidth,


### PR DESCRIPTION
1. Due to different agents implementations, using padding-top with percentage will not work inside flex elements will not work in older versions of firefox and edge. This commit fixes that by making their container "block" on the desired layouts.
2. changed gap to grid-gap for wider agents support (including firefox).