### PR TITLE
#EE-21892|Counter Component Missing Error States

### DIFF
--- a/src/components/Counter/Counter.driver.ts
+++ b/src/components/Counter/Counter.driver.ts
@@ -4,7 +4,7 @@ import {
 } from 'wix-ui-test-utils/base-driver';
 import { StylableUnidriverUtil, UniDriver } from 'wix-ui-test-utils/unidriver';
 import style from './Counter.st.css';
-
+import { tooltipDriverFactory as tooltipDriver } from '../Tooltip/Tooltip.driver';
 export interface CounterDriver extends BaseUniDriver {
   isCounterComponentDisabled(): Promise<boolean>;
   isInputComponentDisabled(): Promise<boolean>;
@@ -16,6 +16,7 @@ export interface CounterDriver extends BaseUniDriver {
   pressPlus(): Promise<void>;
   getCounterAriaLabel(): Promise<string>;
   getCounterAriaLabellledby(): Promise<string>;
+  isTooltipExists(): Promise<boolean>;
 }
 
 export const counterDriverFactory = (base: UniDriver): CounterDriver => {
@@ -40,5 +41,8 @@ export const counterDriverFactory = (base: UniDriver): CounterDriver => {
     pressPlus: async () => getPlusButton().click(),
     getCounterAriaLabel: async () => getAriaLabel('label'),
     getCounterAriaLabellledby: async () => getAriaLabel('labelledby'),
+    isTooltipExists: async () => {
+      return base.$('[data-hook="popover-element"]').exists();
+    },
   };
 };

--- a/src/components/Counter/Counter.driver.ts
+++ b/src/components/Counter/Counter.driver.ts
@@ -18,7 +18,7 @@ export interface CounterDriver extends BaseUniDriver {
   pressPlus(): Promise<void>;
   getCounterAriaLabel(): Promise<string>;
   getCounterAriaLabellledby(): Promise<string>;
-  isTooltipExists(): Promise<boolean>;
+  isErrorTooltipExists(): Promise<boolean>;
   getErrorMessageContent(): Promise<void>;
 }
 
@@ -57,7 +57,7 @@ export const counterDriverFactory = (base: UniDriver): CounterDriver => {
     pressPlus: async () => getPlusButton().click(),
     getCounterAriaLabel: async () => getAriaLabel('label'),
     getCounterAriaLabellledby: async () => getAriaLabel('labelledby'),
-    isTooltipExists: async () => {
+    isErrorTooltipExists: async () => {
       return base.$('[data-hook="popover-element"]').exists();
     },
   };

--- a/src/components/Counter/Counter.spec.tsx
+++ b/src/components/Counter/Counter.spec.tsx
@@ -148,7 +148,7 @@ describe('Counter', () => {
     );
   });
 
-  it('should render tooltip component if error messsage is defined', async () => {
+  it('should render tooltip component if in error state and error messsage is defined', async () => {
     const value = 10;
     const driver = createDriver(
       <Counter
@@ -164,6 +164,9 @@ describe('Counter', () => {
 
     expect(await driver.hasCounterComponentError()).toBeTruthy();
     expect(await driver.isTooltipExists()).toBeTruthy();
+    expect(await driver.getErrorMessageContent()).toContain(
+      'something here is not ok',
+    );
   });
 
   it('should NOT render tooltip compoent if error messsage is defined but not in error state', async () => {

--- a/src/components/Counter/Counter.spec.tsx
+++ b/src/components/Counter/Counter.spec.tsx
@@ -163,7 +163,7 @@ describe('Counter', () => {
     );
 
     expect(await driver.hasCounterComponentError()).toBeTruthy();
-    expect(await driver.isTooltipExists()).toBeTruthy();
+    expect(await driver.isErrorTooltipExists()).toBeTruthy();
     expect(await driver.getErrorMessageContent()).toContain(
       'something here is not ok',
     );
@@ -182,7 +182,7 @@ describe('Counter', () => {
       />,
     );
     expect(await driver.hasCounterComponentError()).toBeFalsy();
-    expect(await driver.isTooltipExists()).toBeFalsy();
+    expect(await driver.isErrorTooltipExists()).toBeFalsy();
   });
 
   it('should be in error state without tooltip if there is no error message', async () => {
@@ -198,7 +198,7 @@ describe('Counter', () => {
       />,
     );
     expect(await driver.hasCounterComponentError()).toBeTruthy();
-    expect(await driver.isTooltipExists()).toBeFalsy();
+    expect(await driver.isErrorTooltipExists()).toBeFalsy();
   });
 
   describe('testkit', () => {

--- a/src/components/Counter/Counter.spec.tsx
+++ b/src/components/Counter/Counter.spec.tsx
@@ -148,6 +148,40 @@ describe('Counter', () => {
     );
   });
 
+  it('should render tooltip component if error messsage is defined', async () => {
+    const value = 10;
+    const driver = createDriver(
+      <Counter
+        inputAriaLabel={'amount'}
+        incrementAriaLabel={'increment'}
+        decrementAriaLabel={'decrement'}
+        errorMessage="something here is not ok"
+        onChange={() => {}}
+        value={value}
+        error
+      />,
+    );
+
+    expect(await driver.hasCounterComponentError()).toBeTruthy();
+    expect(await driver.isTooltipExists()).toBeTruthy();
+  });
+
+  it('should be in error state without tooltip if there is no error message', async () => {
+    const value = 10;
+    const driver = createDriver(
+      <Counter
+        inputAriaLabel={'amount'}
+        incrementAriaLabel={'increment'}
+        decrementAriaLabel={'decrement'}
+        onChange={() => {}}
+        value={value}
+        error
+      />,
+    );
+    expect(await driver.hasCounterComponentError()).toBeTruthy();
+    expect(await driver.isTooltipExists()).toBeFalsy();
+  });
+
   describe('testkit', () => {
     it('should exist', async () => {
       expect(

--- a/src/components/Counter/Counter.spec.tsx
+++ b/src/components/Counter/Counter.spec.tsx
@@ -166,6 +166,22 @@ describe('Counter', () => {
     expect(await driver.isTooltipExists()).toBeTruthy();
   });
 
+  it('should NOT render tooltip compoent if error messsage is defined but not in error state', async () => {
+    const value = 10;
+    const driver = createDriver(
+      <Counter
+        inputAriaLabel={'amount'}
+        incrementAriaLabel={'increment'}
+        decrementAriaLabel={'decrement'}
+        errorMessage="something here is not ok"
+        onChange={() => {}}
+        value={value}
+      />,
+    );
+    expect(await driver.hasCounterComponentError()).toBeFalsy();
+    expect(await driver.isTooltipExists()).toBeFalsy();
+  });
+
   it('should be in error state without tooltip if there is no error message', async () => {
     const value = 10;
     const driver = createDriver(

--- a/src/components/Counter/Counter.st.css
+++ b/src/components/Counter/Counter.st.css
@@ -77,6 +77,10 @@
     color: color(value(counterDisabledColor));
 }
 
+.root:error svg {
+    color: value(DefaultErrorColor);
+}
+
 .root input {
     background: color(value(DefaultBackgroundColor));
     padding: 0;

--- a/src/components/Counter/Counter.st.css
+++ b/src/components/Counter/Counter.st.css
@@ -14,7 +14,7 @@
     DefaultDisabledColor: color-3;
     DefaultErrorColor: value(errorColor);
     DefaultBackgroundColor: color-1;
-    DefaultWidth: 96px;
+    DefaultWidth: 104px;
 }
 
 :vars {

--- a/src/components/Counter/Counter.st.css
+++ b/src/components/Counter/Counter.st.css
@@ -81,6 +81,10 @@
     color: value(DefaultErrorColor);
 }
 
+.root .inputWrapper {
+    flex-grow: 1;
+}
+
 .root input {
     background: color(value(DefaultBackgroundColor));
     padding: 0;

--- a/src/components/Counter/Counter.tsx
+++ b/src/components/Counter/Counter.tsx
@@ -108,6 +108,7 @@ export class Counter extends React.Component<CounterProps> {
         </div>
         {shouldShowErrorMessageTooltip && (
           <Tooltip
+            data-hook="dropdown-error-tooltip"
             content={errorMessage}
             placement="top"
             appendTo="window"

--- a/src/components/Counter/Counter.tsx
+++ b/src/components/Counter/Counter.tsx
@@ -7,7 +7,7 @@ import { ReactComponent as Minus } from '../../assets/icons/minus.svg';
 import { TPAComponentProps } from '../../types';
 import { Tooltip } from '../Tooltip';
 import { TooltipSkin } from '../Tooltip/TooltipEnums';
-import StatusAlertSmall from 'wix-ui-icons-common/StatusAlertSmall';
+import { ReactComponent as ErrorIcon } from '../../assets/icons/Error.svg';
 
 export interface CounterProps extends TPAComponentProps {
   onChange(val: string): void;
@@ -101,7 +101,7 @@ export class Counter extends React.Component<CounterProps> {
             appendTo="window"
             skin={TooltipSkin.Error}
           >
-            <StatusAlertSmall className={style.error} />
+            <ErrorIcon className={style.error} />
           </Tooltip>
         )}
         <div className={style.inputWrapper}>

--- a/src/components/Counter/Counter.tsx
+++ b/src/components/Counter/Counter.tsx
@@ -93,23 +93,24 @@ export class Counter extends React.Component<CounterProps> {
         >
           <Plus />
         </Button>
-        <Input
-          aria-label={inputAriaLabel}
-          onChange={ev => onChange(ev.target.value)}
-          type="number"
-          disabled={disabled}
-          min={min}
-          max={max}
-          step={step}
-          error={error}
-          value={value.toString()}
-        />
-
+        <div className={style.inputWrapper}>
+          <Input
+            aria-label={inputAriaLabel}
+            onChange={ev => onChange(ev.target.value)}
+            type="number"
+            disabled={disabled}
+            min={min}
+            max={max}
+            step={step}
+            error={error}
+            value={value.toString()}
+          />
+        </div>
         {shouldShowErrorMessageTooltip && (
           <Tooltip
             content={errorMessage}
             placement="top"
-            appendTo="viewport"
+            appendTo="window"
             skin={TooltipSkin.Error}
           >
             <StatusAlertSmall className={style.error} />

--- a/src/components/Counter/Counter.tsx
+++ b/src/components/Counter/Counter.tsx
@@ -75,6 +75,7 @@ export class Counter extends React.Component<CounterProps> {
       ...rest
     } = this.props;
 
+    const shouldShowErrorMessageTooltip = error && errorMessage;
     return (
       <div
         {...style('root', { disabled, error }, rest)}
@@ -104,7 +105,7 @@ export class Counter extends React.Component<CounterProps> {
           value={value.toString()}
         />
 
-        {errorMessage && (
+        {shouldShowErrorMessageTooltip && (
           <Tooltip
             content={errorMessage}
             placement="top"

--- a/src/components/Counter/Counter.tsx
+++ b/src/components/Counter/Counter.tsx
@@ -93,6 +93,17 @@ export class Counter extends React.Component<CounterProps> {
         >
           <Plus />
         </Button>
+        {shouldShowErrorMessageTooltip && (
+          <Tooltip
+            data-hook="dropdown-error-tooltip"
+            content={errorMessage}
+            placement="top"
+            appendTo="window"
+            skin={TooltipSkin.Error}
+          >
+            <StatusAlertSmall className={style.error} />
+          </Tooltip>
+        )}
         <div className={style.inputWrapper}>
           <Input
             aria-label={inputAriaLabel}
@@ -106,18 +117,6 @@ export class Counter extends React.Component<CounterProps> {
             value={value.toString()}
           />
         </div>
-        {shouldShowErrorMessageTooltip && (
-          <Tooltip
-            data-hook="dropdown-error-tooltip"
-            content={errorMessage}
-            placement="top"
-            appendTo="window"
-            skin={TooltipSkin.Error}
-          >
-            <StatusAlertSmall className={style.error} />
-          </Tooltip>
-        )}
-
         <Button
           aria-label={decrementAriaLabel}
           className={style.btn}

--- a/src/components/Counter/Counter.tsx
+++ b/src/components/Counter/Counter.tsx
@@ -5,6 +5,9 @@ import style from './Counter.st.css';
 import { ReactComponent as Plus } from '../../assets/icons/plus.svg';
 import { ReactComponent as Minus } from '../../assets/icons/minus.svg';
 import { TPAComponentProps } from '../../types';
+import { Tooltip } from '../Tooltip';
+import { TooltipSkin } from '../Tooltip/TooltipEnums';
+import StatusAlertSmall from 'wix-ui-icons-common/StatusAlertSmall';
 
 export interface CounterProps extends TPAComponentProps {
   onChange(val: string): void;
@@ -19,6 +22,7 @@ export interface CounterProps extends TPAComponentProps {
   max?: number;
   error?: boolean;
   disabled?: boolean;
+  errorMessage?: string;
 }
 
 interface DefaultProps {
@@ -67,6 +71,7 @@ export class Counter extends React.Component<CounterProps> {
       onChange,
       value,
       error,
+      errorMessage,
       ...rest
     } = this.props;
 
@@ -95,8 +100,21 @@ export class Counter extends React.Component<CounterProps> {
           min={min}
           max={max}
           step={step}
+          error={error}
           value={value.toString()}
         />
+
+        {errorMessage && (
+          <Tooltip
+            content={errorMessage}
+            placement="top"
+            appendTo="viewport"
+            skin={TooltipSkin.Error}
+          >
+            <StatusAlertSmall className={style.error} />
+          </Tooltip>
+        )}
+
         <Button
           aria-label={decrementAriaLabel}
           className={style.btn}

--- a/src/components/Counter/docs/index.story.tsx
+++ b/src/components/Counter/docs/index.story.tsx
@@ -71,7 +71,7 @@ export default {
             { title: 'Disabled', source: `<Counter disabled={true} />` },
             {
               title: 'Error',
-              source: `<Counter error={true} errorMessage="I'm am error message"/>`,
+              source: `<Counter error={true} errorMessage="Something is fishy here..."/>`,
             },
           ].map(code),
         ],

--- a/src/components/Counter/docs/index.story.tsx
+++ b/src/components/Counter/docs/index.story.tsx
@@ -71,7 +71,7 @@ export default {
             { title: 'Disabled', source: `<Counter disabled={true} />` },
             {
               title: 'Error',
-              source: `<Counter error={true} errorMessage="Something is fishy here..."/>`,
+              source: `<Counter error={true} errorMessage="This is an error message"/>`,
             },
           ].map(code),
         ],

--- a/src/components/Counter/docs/index.story.tsx
+++ b/src/components/Counter/docs/index.story.tsx
@@ -69,7 +69,10 @@ export default {
           ...[
             { title: 'Regular', source: `<Counter />` },
             { title: 'Disabled', source: `<Counter disabled={true} />` },
-            { title: 'Error', source: `<Counter error={true} />` },
+            {
+              title: 'Error',
+              source: `<Counter error={true} errorMessage="I'm am error message"/>`,
+            },
           ].map(code),
         ],
       }),


### PR DESCRIPTION
This PR contains changes to Counter component. 
changes include: a tooltip that is shown if the user chooses to show an error message while the component is in error state.
Related jira [here](https://jira.wixpress.com/browse/EE-21892)