### PR TITLE
States button remove div

### DIFF
--- a/src/components/StatesButton/StatesButton.st.css
+++ b/src/components/StatesButton/StatesButton.st.css
@@ -19,7 +19,7 @@
 .root::content {
     line-height: 1.5;
     display: block;
-    margin: 3px;
+    padding: 3px;
 }
 
 .successIcon {

--- a/src/components/StatesButton/StatesButton.st.css
+++ b/src/components/StatesButton/StatesButton.st.css
@@ -5,7 +5,6 @@
 
 .root {
     -st-extends: TPAButton;
-    padding:16px 8px 16px 8px;
     position: relative;
     cursor: pointer;
     display: block;
@@ -17,21 +16,16 @@
     box-sizing: border-box;
 }
 
+.root::content {
+    line-height: 1.5;
+    display: block;
+    margin: 3px;
+}
+
 .successIcon {
     position: relative;
     top: 0.15em;
     animation: bounce-in 0.5s ease 0s 1 normal;
-}
-
-.text {
-    line-height: 1.5;
-    display: inline-block;
-    margin: 3px;
-}
-
-.hideText {
-    opacity: 0;
-    width: 0;
 }
 
 @keyframes bounce-in {

--- a/src/components/StatesButton/StatesButton.tsx
+++ b/src/components/StatesButton/StatesButton.tsx
@@ -36,6 +36,12 @@ export class StatesButton extends React.Component<
     this.setState({ success: false });
   }
 
+  private renderCheck() {
+    return <div className={classNames(style.text, style.successIcon)}>
+      <Check size="1em" data-hook={'checkIcon'}/>
+    </div>;
+  }
+
   public render() {
     const { text, disabled, dataHook, ...rest } = this.props;
     const { success } = this.state;
@@ -47,18 +53,7 @@ export class StatesButton extends React.Component<
         ref={this.buttonRef}
         {...style('root', {}, this.props)}
       >
-        <div
-          className={classNames(style.text, {
-            [style.hideText]: success,
-          })}
-        >
-          {text}
-        </div>
-        {success && (
-          <div className={classNames(style.text, style.successIcon)}>
-            <Check size="1em" data-hook={'checkIcon'} />
-          </div>
-        )}
+        {success ? this.renderCheck() : text}
       </Button>
     );
   }

--- a/src/components/StatesButton/StatesButton.tsx
+++ b/src/components/StatesButton/StatesButton.tsx
@@ -38,7 +38,7 @@ export class StatesButton extends React.Component<
 
   private renderCheck() {
     return (
-      <div className={classNames(style.text, style.successIcon)}>
+      <div className={classNames(style.successIcon)}>
         <Check size="1em" data-hook={'checkIcon'} />
       </div>
     );

--- a/src/components/StatesButton/StatesButton.tsx
+++ b/src/components/StatesButton/StatesButton.tsx
@@ -37,9 +37,11 @@ export class StatesButton extends React.Component<
   }
 
   private renderCheck() {
-    return <div className={classNames(style.text, style.successIcon)}>
-      <Check size="1em" data-hook={'checkIcon'}/>
-    </div>;
+    return (
+      <div className={classNames(style.text, style.successIcon)}>
+        <Check size="1em" data-hook={'checkIcon'} />
+      </div>
+    );
   }
 
   public render() {


### PR DESCRIPTION
This PR was created because of a bug in the StatesButton - If you set the button's font through settings, and select an underline decoration, it won't show because of the inner StatesButton hierarchy, which puts the button's text inside a div. 