### PR TITLE
<Badge/> - change default colors

### DIFF
--- a/src/components/Badge/Badge.st.css
+++ b/src/components/Badge/Badge.st.css
@@ -18,13 +18,11 @@
     /*Overrides*/
     BadgeBgColor: --overridable;
     BadgeTextColor: --overridable;
-    BadgeBorderColor: --overridable;
 }
 
 :vars {
     badgeBgColor: color(fallback(value(BadgeBgColor), applyOpacity(color(value(DefaultBgColor)), 0.1)));
     badgeTextColor: color(fallback(value(BadgeTextColor), value(DefaultTextColor)));
-    badgeBorderColor: color(fallback(value(BadgeBorderColor), transparent));
     lightBorderColor: applyOpacity(color(value(LightBorderColor)), 0.10);
 }
 
@@ -35,14 +33,12 @@
     padding: 0 12px;
     line-height: 20px;
     font-size: 12px;
-    border-width: 1px;
-    border-style: solid;
 }
 
 .root:priority(default) {
     background-color: value(badgeBgColor);
     color: value(badgeTextColor);
-    border-color: value(badgeBorderColor);
+    border: none;
 }
 
 .root:priority(light) {
@@ -50,6 +46,8 @@
     color: color(value(LightTextColor));
     border-color: value(lightBorderColor);
     box-sizing: border-box;
+    border-width: 1px;
+    border-style: solid;
 }
 
 .root:priority(primary) {

--- a/src/components/Badge/Badge.st.css
+++ b/src/components/Badge/Badge.st.css
@@ -6,7 +6,7 @@
 :vars {
     /*Defaults*/
     DefaultBgColor: color-5;
-    DefaultTextColor: color-1;
+    DefaultTextColor: color-5;
     LightBgColor: color-1;
     LightTextColor: color-5;
     LightBorderColor: color-5;
@@ -22,10 +22,9 @@
 }
 
 :vars {
-    badgeBgColor: color(fallback(value(BadgeBgColor), value(DefaultBgColor)));
+    badgeBgColor: color(fallback(value(BadgeBgColor), applyOpacity(color(value(DefaultBgColor)), 0.1)));
     badgeTextColor: color(fallback(value(BadgeTextColor), value(DefaultTextColor)));
     badgeBorderColor: color(fallback(value(BadgeBorderColor), transparent));
-    defaultBgColor: applyOpacity(color(value(DefaultBgColor)), 0.4);
     lightBorderColor: applyOpacity(color(value(LightBorderColor)), 0.15);
 }
 
@@ -38,15 +37,12 @@
     font-size: 12px;
     border-width: 1px;
     border-style: solid;
-    background-color: value(badgeBgColor);
-    color: value(badgeTextColor);
-    border-color: value(badgeBorderColor);
 }
 
 .root:priority(default) {
-    background-color: value(defaultBgColor);
-    color: color(value(DefaultTextColor));
-    border: none;
+    background-color: value(badgeBgColor);
+    color: value(badgeTextColor);
+    border-color: value(badgeBorderColor);
 }
 
 .root:priority(light) {

--- a/src/components/Badge/Badge.st.css
+++ b/src/components/Badge/Badge.st.css
@@ -48,6 +48,7 @@
     box-sizing: border-box;
     border-width: 1px;
     border-style: solid;
+    line-height: 18px;
 }
 
 .root:priority(primary) {

--- a/src/components/Badge/Badge.st.css
+++ b/src/components/Badge/Badge.st.css
@@ -49,6 +49,7 @@
     background-color: color(value(LightBgColor));
     color: color(value(LightTextColor));
     border-color: value(lightBorderColor);
+    box-sizing: border-box;
 }
 
 .root:priority(primary) {

--- a/src/components/Badge/Badge.st.css
+++ b/src/components/Badge/Badge.st.css
@@ -25,7 +25,7 @@
     badgeBgColor: color(fallback(value(BadgeBgColor), applyOpacity(color(value(DefaultBgColor)), 0.1)));
     badgeTextColor: color(fallback(value(BadgeTextColor), value(DefaultTextColor)));
     badgeBorderColor: color(fallback(value(BadgeBorderColor), transparent));
-    lightBorderColor: applyOpacity(color(value(LightBorderColor)), 0.15);
+    lightBorderColor: applyOpacity(color(value(LightBorderColor)), 0.10);
 }
 
 .root {

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -13,8 +13,8 @@ export interface BadgeProps extends TPAComponentProps {
   priority?: BADGE_PRIORITY;
 }
 
-export interface DefaultProps{
-  priority: BADGE_PRIORITY,
+interface DefaultProps{
+  priority: BADGE_PRIORITY;
 }
 
 class Badge extends React.Component<BadgeProps> {

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -13,8 +13,13 @@ export interface BadgeProps extends TPAComponentProps {
   priority?: BADGE_PRIORITY;
 }
 
+export interface DefaultProps{
+  priority: BADGE_PRIORITY,
+}
+
 class Badge extends React.Component<BadgeProps> {
   static displayName = 'Badge';
+  static defaultProps: DefaultProps = {priority: BADGE_PRIORITY.default};
 
   render() {
     const { priority, children, ...rest } = this.props;

--- a/src/components/Badge/README.md
+++ b/src/components/Badge/README.md
@@ -13,6 +13,6 @@ The Badge TPA implementation provides a few default overridable styles. By defau
 ## Default theme properties by badge type
 |Badge  |BadgeBgColor|BadgeBorderColor|BadgeTextColor|
 |-------|------------|----------------|--------------|
-|Default|color-5(40%)|-               |color-1       |
+|Default|color-5(10%)|-               |color-5       |
 |Light  |color-1     |color-5(15%)    |color-5       |
 |Primary|color-8     |-               |color-1       |

--- a/src/components/Badge/README.md
+++ b/src/components/Badge/README.md
@@ -14,5 +14,5 @@ The Badge TPA implementation provides a few default overridable styles. By defau
 |Badge  |BadgeBgColor|BadgeBorderColor|BadgeTextColor|
 |-------|------------|----------------|--------------|
 |Default|color-5(10%)|-               |color-5       |
-|Light  |color-1     |color-5(15%)    |color-5       |
+|Light  |color-1     |color-5(10%)    |color-5       |
 |Primary|color-8     |-               |color-1       |

--- a/src/components/Badge/docs/index.story.tsx
+++ b/src/components/Badge/docs/index.story.tsx
@@ -77,11 +77,6 @@ export default {
                     defaultColor: 'color-5',
                   },
                   {
-                    label: 'Badge border color',
-                    wixParam: 'badgeBorderColor',
-                    defaultColor: 'color-5',
-                  },
-                  {
                     label: 'Badge text color',
                     wixParam: 'badgeTextColor',
                     defaultColor: 'color-1',


### PR DESCRIPTION
Changed Badge default colors according to https://www.notion.so/Update-Default-Badge-Wiring-in-Storybook-540ac22d87e84892a337eb842a4207c1.
@jonathanadler 