### PR TITLE
#SCHED-14809 | fix (wix-ui-tpa) prevent recursive calls to componentDidMount

### DIFF
--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -12,7 +12,7 @@ import style from './Tabs.st.css';
 import { TABS_DATA_HOOKS, TABS_DATA_KEYS } from './dataHooks';
 import { TPAComponentProps } from '../../types';
 
-const SCROLL_EPSILON = 1;
+const SCROLL_EPSILON = 15;
 
 export interface TabsProps extends TPAComponentProps {
   /** tabs to be displayed */


### PR DESCRIPTION
After deep investigation, I’ve discovered that the **componentDidUpdate** method in wix-ui-tpa **tabs** was called recursively in Microsoft Edge and IE.
I’ve found that for some reason the error occurs when the user scrolls to the end of the bar, and it seems to be related with the disappearing of the navigational arrows. I’ve increased the value of SCROLL_EPSILON which seems to fix it. can you review the changes? the value 15 was chosen since it is the width of the arrow, and seems to provide the smoothest behavior.