### PR TITLE
#EE-22608 | disallow decimal points in a counter input

### DIFF
--- a/src/components/Counter/Counter.spec.tsx
+++ b/src/components/Counter/Counter.spec.tsx
@@ -144,23 +144,6 @@ describe('Counter', () => {
     expect(onChange).toHaveBeenCalledWith('10');
   });
 
-  it('should sanitize a typed input', async () => {
-    const onChange = jest.fn();
-    const driver = createDriver(
-      <Counter
-        inputAriaLabel={'amount'}
-        incrementAriaLabel={'increment'}
-        decrementAriaLabel={'decrement'}
-        onChange={onChange}
-        step={1}
-        value={0}
-      />,
-    );
-
-    await driver.enterValue('10.');
-    expect(onChange).toHaveBeenCalledWith('10');
-  });
-
   it('should have default role attribute and aria-labelledby attribute', async () => {
     const value = 10;
     const counterAriaLabelledBy = 'labelled by testy test';

--- a/src/components/Counter/Counter.spec.tsx
+++ b/src/components/Counter/Counter.spec.tsx
@@ -144,6 +144,23 @@ describe('Counter', () => {
     expect(onChange).toHaveBeenCalledWith('10');
   });
 
+  it('should sanitize a typed input', async () => {
+    const onChange = jest.fn();
+    const driver = createDriver(
+      <Counter
+        inputAriaLabel={'amount'}
+        incrementAriaLabel={'increment'}
+        decrementAriaLabel={'decrement'}
+        onChange={onChange}
+        step={1}
+        value={0}
+      />,
+    );
+
+    await driver.enterValue('10.');
+    expect(onChange).toHaveBeenCalledWith('10');
+  });
+
   it('should have default role attribute and aria-labelledby attribute', async () => {
     const value = 10;
     const counterAriaLabelledBy = 'labelled by testy test';

--- a/src/components/Counter/Counter.tsx
+++ b/src/components/Counter/Counter.tsx
@@ -23,11 +23,13 @@ export interface CounterProps extends TPAComponentProps {
   error?: boolean;
   disabled?: boolean;
   errorMessage?: string;
+  inputType: 'number' | 'text';
 }
 
 interface DefaultProps {
   step: number;
   value: number;
+  inputType: 'number' | 'text';
 }
 
 /** Counter */
@@ -36,6 +38,7 @@ export class Counter extends React.Component<CounterProps> {
   static defaultProps: DefaultProps = {
     step: 1,
     value: 0,
+    inputType: 'number',
   };
 
   _onDecrement = () => {
@@ -64,6 +67,7 @@ export class Counter extends React.Component<CounterProps> {
       incrementAriaLabel,
       decrementAriaLabel,
       inputAriaLabel,
+      inputType,
       min,
       max,
       step,
@@ -107,9 +111,8 @@ export class Counter extends React.Component<CounterProps> {
         <div className={style.inputWrapper}>
           <Input
             aria-label={inputAriaLabel}
-            onChange={ev => onChange(ev.target.value.replace(/\D/g, ''))}
-            type="text"
-            pattern="[0-9]"
+            onChange={ev => onChange(ev.target.value)}
+            type={inputType}
             disabled={disabled}
             min={min}
             max={max}

--- a/src/components/Counter/Counter.tsx
+++ b/src/components/Counter/Counter.tsx
@@ -107,8 +107,9 @@ export class Counter extends React.Component<CounterProps> {
         <div className={style.inputWrapper}>
           <Input
             aria-label={inputAriaLabel}
-            onChange={ev => onChange(ev.target.value)}
-            type="number"
+            onChange={ev => onChange(ev.target.value.replace(/\D/g, ''))}
+            type="text"
+            pattern="[0-9]"
             disabled={disabled}
             min={min}
             max={max}

--- a/src/components/Counter/Counter.tsx
+++ b/src/components/Counter/Counter.tsx
@@ -23,7 +23,7 @@ export interface CounterProps extends TPAComponentProps {
   error?: boolean;
   disabled?: boolean;
   errorMessage?: string;
-  inputType: 'number' | 'text';
+  inputType?: 'number' | 'text';
 }
 
 interface DefaultProps {


### PR DESCRIPTION
Allow `inputType` as a prop

A `number` input does not trigger an `onChange` event, therefore, we cannot sanitize it

https://jira.wixpress.com/browse/EE-22608