### PR TITLE
few size optimizations

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { Checkbox as CoreCheckbox } from 'wix-ui-core/checkbox';
-import {
-  CheckboxChecked,
-  CheckboxIndeterminate,
-} from 'wix-ui-icons-common/system';
+import CheckboxChecked from 'wix-ui-icons-common/system/CheckboxChecked';
+import CheckboxIndeterminate from 'wix-ui-icons-common/system/CheckboxIndeterminate';
 import { CHECKBOX_DATA_HOOKS, CHEKCBOX_DATA_KEYS } from './dataHooks';
 import { TPAComponentProps } from '../../types';
 import styles from './Checkbox.st.css';

--- a/src/components/DotNavigation/DotNavigation.tsx
+++ b/src/components/DotNavigation/DotNavigation.tsx
@@ -3,8 +3,10 @@ import styles from './DotNavigation.st.css';
 import { RadioButton, RadioButtonKeyDownEvent } from 'wix-ui-core/radio-button';
 import { DotNavigationDataKeys, DotNavigationDataHooks } from './dataHooks';
 import classNames from 'classnames';
-import isNaN from 'lodash/isNaN';
-import isNumber from 'lodash/isNumber';
+
+const isNan = require('lodash/isNan');
+const isNumber = require('lodash/isNumber');
+
 import { TPAComponentProps } from '../../types';
 
 const MAX_SHORT_LIST_LENGTH = 5;

--- a/src/components/DotNavigation/DotNavigation.tsx
+++ b/src/components/DotNavigation/DotNavigation.tsx
@@ -4,7 +4,7 @@ import { RadioButton, RadioButtonKeyDownEvent } from 'wix-ui-core/radio-button';
 import { DotNavigationDataKeys, DotNavigationDataHooks } from './dataHooks';
 import classNames from 'classnames';
 
-const isNan = require('lodash/isNan');
+const isNaN = require('lodash/isNaN');
 const isNumber = require('lodash/isNumber');
 
 import { TPAComponentProps } from '../../types';

--- a/src/components/DotNavigation/DotNavigation.tsx
+++ b/src/components/DotNavigation/DotNavigation.tsx
@@ -3,7 +3,8 @@ import styles from './DotNavigation.st.css';
 import { RadioButton, RadioButtonKeyDownEvent } from 'wix-ui-core/radio-button';
 import { DotNavigationDataKeys, DotNavigationDataHooks } from './dataHooks';
 import classNames from 'classnames';
-import * as _ from 'lodash';
+import isNaN from 'lodash/isNaN';
+import isNumber from 'lodash/isNumber';
 import { TPAComponentProps } from '../../types';
 
 const MAX_SHORT_LIST_LENGTH = 5;
@@ -89,7 +90,7 @@ interface RadioButtonProps {
   ariaLabel: null | string;
 }
 
-const isNumber = (value: any) => _.isNumber(value) && !_.isNaN(value);
+const _isNumber = (value: any) => isNumber(value) && !isNaN(value);
 
 const getFiveFromStart = (start: number) => [
   start,
@@ -133,7 +134,7 @@ export class DotNavigation extends React.Component<
     savedCurrentIndex: number,
     length: number,
   ) =>
-    isNumber(currentIndex) &&
+    _isNumber(currentIndex) &&
     currentIndex >= 0 &&
     currentIndex < length &&
     currentIndex !== savedCurrentIndex;
@@ -271,7 +272,7 @@ export class DotNavigation extends React.Component<
       })}
     >
       {this.renderFakeRadio()}
-      {!isNumber(this.props.currentIndex) ||
+      {!_isNumber(this.props.currentIndex) ||
       this.props.currentIndex < MAX_SHORT_LIST_LENGTH - NUM_OF_NAV_DOTS
         ? this.renderStartList()
         : this.props.currentIndex >=
@@ -309,7 +310,7 @@ export class DotNavigation extends React.Component<
   render = () => {
     const { length, ...rest } = this.props;
 
-    return isNumber(length) && length > 0 ? (
+    return _isNumber(length) && length > 0 ? (
       <div {...styles('root', {}, rest)} {...this._getDataAttributes()}>
         {length <= MAX_SHORT_LIST_LENGTH
           ? this.renderShortVersion()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
     "paths": {
       "protractor": ["test/protractor.d.ts"]
     },
-    "esModuleInterop": true
   },
   "include": [
     "./node_modules/wix-ui-core/dist/src/globals.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "baseUrl": ".",
     "paths": {
       "protractor": ["test/protractor.d.ts"]
-    },
+    }
   },
   "include": [
     "./node_modules/wix-ui-core/dist/src/globals.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "baseUrl": ".",
     "paths": {
       "protractor": ["test/protractor.d.ts"]
-    }
+    },
+    "esModuleInterop": true
   },
   "include": [
     "./node_modules/wix-ui-core/dist/src/globals.d.ts",


### PR DESCRIPTION
I am working on reducing our bundle size and have noticed that in `wix-ui-tpa` there are few things that could be optimized. Namely `wix-ui-icons-common` and `lodash`
my suggestions work for `wix-ui-icons-common` but, sadly not for `lodash` (maybe add it to externals?)

Before 

<img width="1872" alt="Screen Shot 2020-03-30 at 10 32 55 PM" src="https://user-images.githubusercontent.com/4746211/77954143-e217cd80-72d6-11ea-9da9-9e2056899dda.png">

After 

<img width="1870" alt="Screen Shot 2020-03-30 at 10 38 05 PM" src="https://user-images.githubusercontent.com/4746211/77954485-5488ad80-72d7-11ea-9714-032b7ced972f.png">

