### PR TITLE
#EE-23606|dropdown| make down arrow icon align with font size

### DIFF
--- a/src/components/Dropdown/Dropdown.st.css
+++ b/src/components/Dropdown/Dropdown.st.css
@@ -96,6 +96,9 @@
 
 .dropdown:content-visible .dropdownBase::arrowIcon {
     transform: rotate(180deg);
+}
+
+.dropdown .dropdownBase::arrowIcon {
     height: 1.5em;
     width: 1.5em;
 }

--- a/src/components/Dropdown/Dropdown.st.css
+++ b/src/components/Dropdown/Dropdown.st.css
@@ -99,6 +99,10 @@
 }
 
 .dropdown .dropdownBase::arrowIcon {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
     height: 1.5em;
     width: 1.5em;
 }

--- a/src/components/Dropdown/Dropdown.st.css
+++ b/src/components/Dropdown/Dropdown.st.css
@@ -95,7 +95,7 @@
 }
 
 .dropdown:content-visible .dropdownBase::arrowIcon {
-    transform: rotate(180deg);
+    transform: translateY(-50%) rotate(180deg);
 }
 
 .dropdown .dropdownBase::arrowIcon {

--- a/src/components/Dropdown/Dropdown.st.css
+++ b/src/components/Dropdown/Dropdown.st.css
@@ -96,6 +96,8 @@
 
 .dropdown:content-visible .dropdownBase::arrowIcon {
     transform: rotate(180deg);
+    height: 1.5em;
+    width: 1.5em;
 }
 
 .dropdown .dropdownBase::arrowIcon path {


### PR DESCRIPTION
in dropdown => make down arrow icon align with font size of text

https://jira.wixpress.com/browse/EE-23606?page=com.wixpress.vi.jira-git-commits%3Acommits-plugin