### PR TITLE
Feat/checkbox box and more

### DIFF
--- a/src/components/Checkbox/Checkbox.driver.ts
+++ b/src/components/Checkbox/Checkbox.driver.ts
@@ -42,7 +42,11 @@ export const checkboxDriverFactory = (base: UniDriver): CheckboxDriver => {
       return Simulate.change(inputNative);
     },
     async hoverCheckbox() {
-      return base.$(`${iconDatahook}`).hover();
+      return new Promise(async done => {
+        await base.$(`${iconDatahook}`).hover();
+        // wait for transition to end
+        setTimeout(done, 200);
+      });
     },
     async getBorderColor() {
       const icon = getIcon();

--- a/src/components/Checkbox/Checkbox.meta.tsx
+++ b/src/components/Checkbox/Checkbox.meta.tsx
@@ -38,3 +38,12 @@ CheckboxMetadata.addSim({
     label: 'Amazing',
   },
 });
+
+CheckboxMetadata.addSim({
+  title: 'box',
+  props: {
+    box: true,
+    onChange: () => {},
+    label: 'Amazing',
+  },
+});

--- a/src/components/Checkbox/Checkbox.meta.tsx
+++ b/src/components/Checkbox/Checkbox.meta.tsx
@@ -42,7 +42,7 @@ CheckboxMetadata.addSim({
 CheckboxMetadata.addSim({
   title: 'box',
   props: {
-    box: true,
+    theme: 'box',
     onChange: () => {},
     label: 'Amazing',
   },
@@ -52,7 +52,7 @@ CheckboxMetadata.addSim({
   title: 'suffix',
   props: {
     suffix: '$50,000',
-    box: true,
+    theme: 'box',
     onChange: () => {},
     label: 'Amazing',
   },

--- a/src/components/Checkbox/Checkbox.meta.tsx
+++ b/src/components/Checkbox/Checkbox.meta.tsx
@@ -49,9 +49,9 @@ CheckboxMetadata.addSim({
 });
 
 CheckboxMetadata.addSim({
-  title: 'price',
+  title: 'suffix',
   props: {
-    price: '$50,000',
+    suffix: '$50,000',
     box: true,
     onChange: () => {},
     label: 'Amazing',

--- a/src/components/Checkbox/Checkbox.meta.tsx
+++ b/src/components/Checkbox/Checkbox.meta.tsx
@@ -47,3 +47,13 @@ CheckboxMetadata.addSim({
     label: 'Amazing',
   },
 });
+
+CheckboxMetadata.addSim({
+  title: 'price',
+  props: {
+    price: '$50,000',
+    box: true,
+    onChange: () => {},
+    label: 'Amazing',
+  },
+});

--- a/src/components/Checkbox/Checkbox.meta.tsx
+++ b/src/components/Checkbox/Checkbox.meta.tsx
@@ -1,4 +1,4 @@
-import { Checkbox } from '.';
+import { Checkbox, CheckboxTheme } from '.';
 import Registry from '@ui-autotools/registry';
 
 const CheckboxMetadata = Registry.getComponentMetadata(Checkbox);
@@ -42,7 +42,7 @@ CheckboxMetadata.addSim({
 CheckboxMetadata.addSim({
   title: 'box',
   props: {
-    theme: 'box',
+    theme: CheckboxTheme.Box,
     onChange: () => {},
     label: 'Amazing',
   },
@@ -52,7 +52,7 @@ CheckboxMetadata.addSim({
   title: 'suffix',
   props: {
     suffix: '$50,000',
-    theme: 'box',
+    theme: CheckboxTheme.Box,
     onChange: () => {},
     label: 'Amazing',
   },

--- a/src/components/Checkbox/Checkbox.st.css
+++ b/src/components/Checkbox/Checkbox.st.css
@@ -16,6 +16,7 @@
 :vars {
     /*Defaults*/
     DefaultTextColor: color-5;
+    DefaultBorderColor: color-5;
     DefaultBoxBorderColor: color-5;
     DefaultIconColor: color-8;
     DefaultBoxColor: color-1;
@@ -26,12 +27,14 @@
 :vars {
     /*Overrides*/
     TextColor: --overridable;
+    BorderColor: --overridable;
     BoxBorderColor: --overridable;
     IconColor: --overridable;
     BoxColor: --overridable;
 }
 
 :vars {
+    CurrentBorderColor: color(fallback(value(BorderColor), value(DefaultBorderColor)));
     CurrentBoxBorderColor: color(fallback(value(BoxBorderColor), value(DefaultBoxBorderColor)));
     CurrentIconColor: color(fallback(value(IconColor), value(DefaultIconColor)));
     CurrentTextColor: color(fallback(value(TextColor), value(DefaultTextColor)));
@@ -91,7 +94,7 @@
     height: 16px;
 
     border: 1px solid;
-    border-color: applyOpacity(value(CurrentTextColor), 0.6);
+    border-color: applyOpacity(value(CurrentBorderColor), 0.6);
     border-radius: 1px;
 
     font-size: 13px;

--- a/src/components/Checkbox/Checkbox.st.css
+++ b/src/components/Checkbox/Checkbox.st.css
@@ -43,6 +43,8 @@
     border: 1px solid applyOpacity(value(CurrentBorderColor), 0.6);
     margin-bottom: 16px;
     cursor: pointer;
+    width: 100%;
+    box-sizing: border-box;
 }
 
 .root {
@@ -54,6 +56,7 @@
     box-sizing: border-box;
 
     font: value(Font);
+    flex: 1;
 }
 
 .root * {
@@ -62,6 +65,7 @@
 
 .root::childContainer {
     display: flex;
+    flex: 1;
 }
 
 .root::box {
@@ -103,6 +107,14 @@
 .label {
     display: inline-block;
     color: value(CurrentTextColor);
+}
+
+.price {
+    margin-left: 5px;
+}
+
+.box .price {
+    margin-left: auto;
 }
 
 /* STATES */

--- a/src/components/Checkbox/Checkbox.st.css
+++ b/src/components/Checkbox/Checkbox.st.css
@@ -49,6 +49,7 @@
     box-sizing: border-box;
 
     font: value(Font);
+    transition: background-color 0.2s linear, border-color 0.2s linear;
 }
 
 .root * {
@@ -81,11 +82,34 @@
 
 .root:box {
     display: flex;
-    padding: 16px;
     background-color: color(value(CurrentBoxColor));
     border: 1px solid applyOpacity(value(CurrentBoxBorderColor), 0.6);
-    cursor: pointer;
     box-sizing: border-box;
+    position: relative;
+}
+
+.root:box::after {
+    content: '';
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: -1px;
+    left: -1px;
+    display: block;
+    background-color: applyOpacity(value(CurrentIconColor), 0.1);
+    border: 1px solid color(value(CurrentIconColor));
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.2s linear;
+}
+
+.root:box::childContainer {
+    padding: 16px;
+    padding-left: 0;
+}
+
+.root:box::box {
+    padding-left: 16px;
 }
 
 .icon {
@@ -100,6 +124,7 @@
     font-size: 13px;
     line-height: 1.2;
     vertical-align: middle;
+    transition: border-color 0.2s linear;
 }
 
 .icon svg {
@@ -134,11 +159,7 @@
 }
 
 /* STATES */
-.root:box:disabled {
-    cursor: default;
-}
-
-.root:box:hover, .root:box:focus-within {
+.root:hover:box, .root:focus-within:box {
     border-color: applyOpacity(value(CurrentBoxBorderColor), 1);
 }
 
@@ -146,20 +167,11 @@
     border-color: applyOpacity(value(CurrentBoxBorderColor), 0.6);
 }
 
-.root:box:checked {
-    background-color: applyOpacity(value(CurrentIconColor), 0.1);
-    border-color: value(CurrentIconColor);
+.root:box:checked::after {
+    opacity: 1;
 }
 
-.root:box:checked:not(:disabled):hover, .root:box:checked:not(:disabled):focus-within {
-    border-color: applyOpacity(value(CurrentIconColor), 0.6);
-}
-
-.root:box:not(:disabled):hover .icon {
-    border-color: applyOpacity(value(CurrentBoxBorderColor), 1);
-}
-
-.root:hover .icon {
+.root:hover .icon, .root:focus-within .icon {
     border-color: applyOpacity(value(CurrentBorderColor), 1);
 }
 

--- a/src/components/Checkbox/Checkbox.st.css
+++ b/src/components/Checkbox/Checkbox.st.css
@@ -59,7 +59,12 @@
 
 .root::box {
     line-height: 0;
-    margin-right: 12px;
+    display: flex;
+}
+
+.root::box:after {
+    content: '';
+    width: 12px;
 }
 
 .core {
@@ -109,9 +114,14 @@
 }
 
 .label.suffixed {
-    margin-right: 5px;
     flex: 1;
     white-space: nowrap;
+    display: flex;
+}
+
+.label.suffixed:after {
+    content: '';
+    width: 5px;
 }
 
 .suffix {

--- a/src/components/Checkbox/Checkbox.st.css
+++ b/src/components/Checkbox/Checkbox.st.css
@@ -62,7 +62,7 @@
     display: flex;
 }
 
-.root::box:after {
+.root::box::after {
     content: '';
     width: 12px;
 }
@@ -119,7 +119,7 @@
     display: flex;
 }
 
-.label.suffixed:after {
+.label.suffixed::after {
     content: '';
     width: 5px;
 }

--- a/src/components/Checkbox/Checkbox.st.css
+++ b/src/components/Checkbox/Checkbox.st.css
@@ -27,12 +27,22 @@
     TextColor: --overridable;
     BorderColor: --overridable;
     IconColor: color-8;
+    BoxColor: color-1;
 }
 
 :vars {
     CurrentBorderColor: color(fallback(value(BorderColor), value(DefaultBorderColor)));
     CurrentIconColor: color(fallback(value(IconColor), value(DefaultIconColor)));
     CurrentTextColor: color(fallback(value(TextColor), value(DefaultTextColor)));
+}
+
+.box {
+    display: flex;
+    padding: 16px;
+    background-color: color(color-1);
+    border: 1px solid applyOpacity(value(CurrentBorderColor), 0.6);
+    margin-bottom: 16px;
+    cursor: pointer;
 }
 
 .root {
@@ -96,6 +106,35 @@
 }
 
 /* STATES */
+.box.disabled {
+    cursor: default;
+}
+
+.box:hover, .box:focus-within {
+    border-color: applyOpacity(value(CurrentBorderColor), 1);
+}
+
+.box.disabled:hover:not(.checked), .box.disabled:focus-within:not(.checked) {
+    border-color: applyOpacity(value(CurrentBorderColor), 0.6);
+}
+
+.box.checked {
+    background-color: applyOpacity(value(CurrentIconColor), 0.1);
+    border-color: value(CurrentIconColor);
+}
+
+.box.checked:not(.disabled):hover, .box.checked:not(.disabled):focus-within {
+    border-color: applyOpacity(value(CurrentIconColor), 0.6);
+}
+
+.box:not(.disabled):hover .icon {
+    border-color: applyOpacity(value(CurrentBorderColor), 1);
+}
+
+.box:last-of-type {
+    margin-bottom: 0;
+}
+
 .root:hover .icon {
     border-color: applyOpacity(value(CurrentBorderColor), 1);
 }

--- a/src/components/Checkbox/Checkbox.st.css
+++ b/src/components/Checkbox/Checkbox.st.css
@@ -109,11 +109,11 @@
     color: value(CurrentTextColor);
 }
 
-.price {
+.suffix {
     margin-left: 5px;
 }
 
-.box .price {
+.box .suffix {
     margin-left: auto;
 }
 

--- a/src/components/Checkbox/Checkbox.st.css
+++ b/src/components/Checkbox/Checkbox.st.css
@@ -36,27 +36,14 @@
     CurrentTextColor: color(fallback(value(TextColor), value(DefaultTextColor)));
 }
 
-.box {
-    display: flex;
-    padding: 16px;
-    background-color: color(color-1);
-    border: 1px solid applyOpacity(value(CurrentBorderColor), 0.6);
-    margin-bottom: 16px;
-    cursor: pointer;
-    width: 100%;
-    box-sizing: border-box;
-}
-
 .root {
     -st-extends: Checkbox;
-    -st-states: checked, disabled, error;
+    -st-states: box, checked, disabled, error;
 
     display: inline-flex;
-    align-items: flex-start;
     box-sizing: border-box;
 
     font: value(Font);
-    flex: 1;
 }
 
 .root * {
@@ -66,10 +53,29 @@
 .root::childContainer {
     display: flex;
     flex: 1;
+    flex-wrap: wrap;
+    align-items: center;
 }
 
 .root::box {
-    line-height: 20px;
+    line-height: 0;
+    margin-right: 12px;
+}
+
+.core {
+    width: 100%;
+    display: flex;
+    align-items: center;
+}
+
+
+.root:box {
+    display: flex;
+    padding: 16px;
+    background-color: color(color-1);
+    border: 1px solid applyOpacity(value(CurrentBorderColor), 0.6);
+    cursor: pointer;
+    box-sizing: border-box;
 }
 
 .icon {
@@ -93,13 +99,6 @@
     height: 7px;
 }
 
-.divider {
-    display: inline-block;
-    width: 12px;
-
-    flex-shrink: 0;
-}
-
 .icon path {
     fill: value(CurrentIconColor);
 }
@@ -109,42 +108,40 @@
     color: value(CurrentTextColor);
 }
 
-.suffix {
-    margin-left: 5px;
+.label.suffixed {
+    margin-right: 5px;
+    flex: 1;
+    white-space: nowrap;
 }
 
-.box .suffix {
-    margin-left: auto;
+.suffix {
+    flex: 0;
 }
 
 /* STATES */
-.box.disabled {
+.root:box:disabled {
     cursor: default;
 }
 
-.box:hover, .box:focus-within {
+.root:box:hover, .root:box:focus-within {
     border-color: applyOpacity(value(CurrentBorderColor), 1);
 }
 
-.box.disabled:hover:not(.checked), .box.disabled:focus-within:not(.checked) {
+.root:box.disabled:hover:not(:checked), .root:box:disabled:focus-within:not(:checked) {
     border-color: applyOpacity(value(CurrentBorderColor), 0.6);
 }
 
-.box.checked {
+.root:box:checked {
     background-color: applyOpacity(value(CurrentIconColor), 0.1);
     border-color: value(CurrentIconColor);
 }
 
-.box.checked:not(.disabled):hover, .box.checked:not(.disabled):focus-within {
+.root:box:checked:not(:disabled):hover, .root:box:checked:not(:disabled):focus-within {
     border-color: applyOpacity(value(CurrentIconColor), 0.6);
 }
 
-.box:not(.disabled):hover .icon {
+.root:box:not(:disabled):hover .icon {
     border-color: applyOpacity(value(CurrentBorderColor), 1);
-}
-
-.box:last-of-type {
-    margin-bottom: 0;
 }
 
 .root:hover .icon {

--- a/src/components/Checkbox/Checkbox.st.css
+++ b/src/components/Checkbox/Checkbox.st.css
@@ -16,8 +16,9 @@
 :vars {
     /*Defaults*/
     DefaultTextColor: color-5;
-    DefaultBorderColor: color-5;
+    DefaultBoxBorderColor: color-5;
     DefaultIconColor: color-8;
+    DefaultBoxColor: color-1;
     DisabledColor: color-3;
     Font: font("{theme: 'Body-M', size: '16px', lineHeight: '24px'}");
 }
@@ -25,15 +26,16 @@
 :vars {
     /*Overrides*/
     TextColor: --overridable;
-    BorderColor: --overridable;
-    IconColor: color-8;
-    BoxColor: color-1;
+    BoxBorderColor: --overridable;
+    IconColor: --overridable;
+    BoxColor: --overridable;
 }
 
 :vars {
-    CurrentBorderColor: color(fallback(value(BorderColor), value(DefaultBorderColor)));
+    CurrentBoxBorderColor: color(fallback(value(BoxBorderColor), value(DefaultBoxBorderColor)));
     CurrentIconColor: color(fallback(value(IconColor), value(DefaultIconColor)));
     CurrentTextColor: color(fallback(value(TextColor), value(DefaultTextColor)));
+    CurrentBoxColor: color(fallback(value(BoxColor), value(DefaultBoxColor)));
 }
 
 .root {
@@ -77,8 +79,8 @@
 .root:box {
     display: flex;
     padding: 16px;
-    background-color: color(color-1);
-    border: 1px solid applyOpacity(value(CurrentBorderColor), 0.6);
+    background-color: color(value(CurrentBoxColor));
+    border: 1px solid applyOpacity(value(CurrentBoxBorderColor), 0.6);
     cursor: pointer;
     box-sizing: border-box;
 }
@@ -89,7 +91,7 @@
     height: 16px;
 
     border: 1px solid;
-    border-color: applyOpacity(value(CurrentBorderColor), 0.6);
+    border-color: applyOpacity(value(CurrentTextColor), 0.6);
     border-radius: 1px;
 
     font-size: 13px;
@@ -134,11 +136,11 @@
 }
 
 .root:box:hover, .root:box:focus-within {
-    border-color: applyOpacity(value(CurrentBorderColor), 1);
+    border-color: applyOpacity(value(CurrentBoxBorderColor), 1);
 }
 
 .root:box.disabled:hover:not(:checked), .root:box:disabled:focus-within:not(:checked) {
-    border-color: applyOpacity(value(CurrentBorderColor), 0.6);
+    border-color: applyOpacity(value(CurrentBoxBorderColor), 0.6);
 }
 
 .root:box:checked {
@@ -151,11 +153,11 @@
 }
 
 .root:box:not(:disabled):hover .icon {
-    border-color: applyOpacity(value(CurrentBorderColor), 1);
+    border-color: applyOpacity(value(CurrentBoxBorderColor), 1);
 }
 
 .root:hover .icon {
-    border-color: applyOpacity(value(CurrentBorderColor), 1);
+    border-color: applyOpacity(value(CurrentBoxBorderColor), 1);
 }
 
 .root:error:not(:hover) .icon {

--- a/src/components/Checkbox/Checkbox.st.css
+++ b/src/components/Checkbox/Checkbox.st.css
@@ -160,7 +160,7 @@
 }
 
 .root:hover .icon {
-    border-color: applyOpacity(value(CurrentBoxBorderColor), 1);
+    border-color: applyOpacity(value(CurrentBorderColor), 1);
 }
 
 .root:error:not(:hover) .icon {

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -19,7 +19,7 @@ export interface CheckboxProps extends TPAComponentProps {
   error?: boolean;
   name?: string;
   box?: boolean;
-  price?: string;
+  suffix?: string;
 }
 
 interface DefaultProps {
@@ -83,7 +83,7 @@ export class Checkbox extends React.Component<CheckboxProps> {
       indeterminate,
       onChange,
       name,
-      price,
+      suffix,
       className,
     } = this.props;
     const iconContent = this._renderIcon();
@@ -114,8 +114,10 @@ export class Checkbox extends React.Component<CheckboxProps> {
             >
               {label}
             </div>
-            {price && (
-              <div className={`${classes.label} ${classes.price}`}>{price}</div>
+            {suffix && (
+              <div className={`${classes.label} ${classes.suffix}`}>
+                {suffix}
+              </div>
             )}
           </>
         </CoreCheckbox>

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -17,6 +17,7 @@ export interface CheckboxProps extends TPAComponentProps {
   indeterminate?: boolean;
   error?: boolean;
   name?: string;
+  box?: boolean;
 }
 
 interface DefaultProps {
@@ -72,6 +73,7 @@ export class Checkbox extends React.Component<CheckboxProps> {
 
   render() {
     const {
+      box,
       checked,
       disabled,
       label,
@@ -84,29 +86,34 @@ export class Checkbox extends React.Component<CheckboxProps> {
     const iconContent = this._renderIcon();
 
     return (
-      <CoreCheckbox
-        className={st(classes.root, { checked, disabled, error }, className)}
-        {...this.getDataAttributes()}
-        data-hook={this.props['data-hook']}
-        checkedIcon={iconContent}
-        uncheckedIcon={iconContent}
-        indeterminateIcon={iconContent}
-        indeterminate={indeterminate}
-        checked={checked}
-        onChange={onChange}
-        name={name}
-        disabled={disabled}
+      <div
+        className={`${box && classes.box} ${checked &&
+          classes.checked} ${disabled && classes.disabled} `}
       >
-        <>
-          {!!label && <span className={classes.divider} />}
-          <div
-            data-hook={CHECKBOX_DATA_HOOKS.LabelWrapper}
-            className={classes.label}
-          >
-            {label}
-          </div>
-        </>
-      </CoreCheckbox>
+        <CoreCheckbox
+          className={st(classes.root, { checked, disabled, error }, className)}
+          {...this.getDataAttributes()}
+          data-hook={this.props['data-hook']}
+          checkedIcon={iconContent}
+          uncheckedIcon={iconContent}
+          indeterminateIcon={iconContent}
+          indeterminate={indeterminate}
+          checked={checked}
+          onChange={onChange}
+          name={name}
+          disabled={disabled}
+        >
+          <>
+            {!!label && <span className={classes.divider} />}
+            <div
+              data-hook={CHECKBOX_DATA_HOOKS.LabelWrapper}
+              className={classes.label}
+            >
+              {label}
+            </div>
+          </>
+        </CoreCheckbox>
+      </div>
     );
   }
 }

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -4,12 +4,14 @@ import CheckboxChecked from 'wix-ui-icons-common/system/CheckboxChecked';
 import CheckboxIndeterminate from 'wix-ui-icons-common/system/CheckboxIndeterminate';
 import { CHECKBOX_DATA_HOOKS, CHEKCBOX_DATA_KEYS } from './dataHooks';
 import { TPAComponentProps } from '../../types';
-import { Text } from '../Text';
 import { st, classes } from './Checkbox.st.css';
 
 interface OnChangeEvent extends React.ChangeEvent<HTMLInputElement> {
   checked: boolean;
 }
+
+type Theme = 'box';
+
 export interface CheckboxProps extends TPAComponentProps {
   onChange(event: OnChangeEvent): void;
   label: React.ReactNode | string;
@@ -18,7 +20,7 @@ export interface CheckboxProps extends TPAComponentProps {
   indeterminate?: boolean;
   error?: boolean;
   name?: string;
-  box?: boolean;
+  theme?: Theme;
   suffix?: string;
 }
 
@@ -75,7 +77,7 @@ export class Checkbox extends React.Component<CheckboxProps> {
 
   render() {
     const {
-      box,
+      theme,
       checked,
       disabled,
       label,
@@ -90,13 +92,16 @@ export class Checkbox extends React.Component<CheckboxProps> {
 
     return (
       <div
-        className={`${box && classes.box} ${checked &&
-          classes.checked} ${disabled && classes.disabled} `}
+        className={st(
+          classes.root,
+          { box: theme === 'box', checked, disabled, error },
+          className,
+        )}
+        data-hook={this.props['data-hook']}
+        {...this.getDataAttributes()}
       >
         <CoreCheckbox
-          className={st(classes.root, { checked, disabled, error }, className)}
-          {...this.getDataAttributes()}
-          data-hook={this.props['data-hook']}
+          className={classes.core}
           checkedIcon={iconContent}
           uncheckedIcon={iconContent}
           indeterminateIcon={iconContent}
@@ -106,20 +111,15 @@ export class Checkbox extends React.Component<CheckboxProps> {
           name={name}
           disabled={disabled}
         >
-          <>
-            {!!label && <span className={classes.divider} />}
-            <div
-              data-hook={CHECKBOX_DATA_HOOKS.LabelWrapper}
-              className={classes.label}
-            >
-              {label}
-            </div>
-            {suffix && (
-              <div className={`${classes.label} ${classes.suffix}`}>
-                {suffix}
-              </div>
-            )}
-          </>
+          <div
+            data-hook={CHECKBOX_DATA_HOOKS.LabelWrapper}
+            className={`${classes.label} ${suffix && classes.suffixed}`}
+          >
+            {label}
+          </div>
+          {suffix && (
+            <div className={`${classes.label} ${classes.suffix}`}>{suffix}</div>
+          )}
         </CoreCheckbox>
       </div>
     );

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import classnames from 'classnames';
 import { Checkbox as CoreCheckbox } from 'wix-ui-core/checkbox';
 import CheckboxChecked from 'wix-ui-icons-common/system/CheckboxChecked';
 import CheckboxIndeterminate from 'wix-ui-icons-common/system/CheckboxIndeterminate';
@@ -10,7 +11,10 @@ interface OnChangeEvent extends React.ChangeEvent<HTMLInputElement> {
   checked: boolean;
 }
 
-type Theme = 'box';
+export enum CheckboxTheme {
+  Default = 'default',
+  Box = 'box',
+}
 
 export interface CheckboxProps extends TPAComponentProps {
   onChange(event: OnChangeEvent): void;
@@ -20,7 +24,7 @@ export interface CheckboxProps extends TPAComponentProps {
   indeterminate?: boolean;
   error?: boolean;
   name?: string;
-  theme?: Theme;
+  theme?: CheckboxTheme;
   suffix?: string;
 }
 
@@ -30,6 +34,7 @@ interface DefaultProps {
   label: string;
   error: false;
   indeterminate: boolean;
+  theme: CheckboxTheme;
   'data-hook': string;
 }
 
@@ -42,6 +47,7 @@ export class Checkbox extends React.Component<CheckboxProps> {
     label: '',
     error: false,
     indeterminate: false,
+    theme: CheckboxTheme.Default,
     'data-hook': CHECKBOX_DATA_HOOKS.CheckboxWrapper,
   };
 
@@ -113,7 +119,9 @@ export class Checkbox extends React.Component<CheckboxProps> {
         >
           <div
             data-hook={CHECKBOX_DATA_HOOKS.LabelWrapper}
-            className={`${classes.label} ${suffix && classes.suffixed}`}
+            className={classnames(classes.label, {
+              [classes.suffixed]: suffix,
+            })}
           >
             {label}
           </div>

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -95,6 +95,7 @@ export class Checkbox extends React.Component<CheckboxProps> {
         checked={checked}
         onChange={onChange}
         name={name}
+        disabled={disabled}
       >
         <>
           {!!label && <span className={classes.divider} />}

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -4,6 +4,7 @@ import CheckboxChecked from 'wix-ui-icons-common/system/CheckboxChecked';
 import CheckboxIndeterminate from 'wix-ui-icons-common/system/CheckboxIndeterminate';
 import { CHECKBOX_DATA_HOOKS, CHEKCBOX_DATA_KEYS } from './dataHooks';
 import { TPAComponentProps } from '../../types';
+import { Text } from '../Text';
 import { st, classes } from './Checkbox.st.css';
 
 interface OnChangeEvent extends React.ChangeEvent<HTMLInputElement> {
@@ -18,6 +19,7 @@ export interface CheckboxProps extends TPAComponentProps {
   error?: boolean;
   name?: string;
   box?: boolean;
+  price?: string;
 }
 
 interface DefaultProps {
@@ -81,6 +83,7 @@ export class Checkbox extends React.Component<CheckboxProps> {
       indeterminate,
       onChange,
       name,
+      price,
       className,
     } = this.props;
     const iconContent = this._renderIcon();
@@ -111,6 +114,9 @@ export class Checkbox extends React.Component<CheckboxProps> {
             >
               {label}
             </div>
+            {price && (
+              <div className={`${classes.label} ${classes.price}`}>{price}</div>
+            )}
           </>
         </CoreCheckbox>
       </div>

--- a/src/components/Checkbox/Checkbox.visual.tsx
+++ b/src/components/Checkbox/Checkbox.visual.tsx
@@ -33,7 +33,7 @@ const tests = [
         },
       },
       {
-        it: 'disbled',
+        it: 'disabled',
         props: {
           disabled: true,
           onChange: () => {},
@@ -59,6 +59,15 @@ const tests = [
       {
         it: 'box',
         props: {
+          box: true,
+          onChange: () => {},
+          label: 'Amazing',
+        },
+      },
+      {
+        it: 'price',
+        props: {
+          price: '$50,000',
           box: true,
           onChange: () => {},
           label: 'Amazing',

--- a/src/components/Checkbox/Checkbox.visual.tsx
+++ b/src/components/Checkbox/Checkbox.visual.tsx
@@ -65,9 +65,9 @@ const tests = [
         },
       },
       {
-        it: 'price',
+        it: 'suffix',
         props: {
-          price: '$50,000',
+          suffix: '$50,000',
           box: true,
           onChange: () => {},
           label: 'Amazing',

--- a/src/components/Checkbox/Checkbox.visual.tsx
+++ b/src/components/Checkbox/Checkbox.visual.tsx
@@ -56,6 +56,14 @@ const tests = [
           label: 'Amazing',
         },
       },
+      {
+        it: 'box',
+        props: {
+          box: true,
+          onChange: () => {},
+          label: 'Amazing',
+        },
+      },
     ],
   },
 ];

--- a/src/components/Checkbox/Checkbox.visual.tsx
+++ b/src/components/Checkbox/Checkbox.visual.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import { VisualTestContainer } from '../../../test/visual/VisualTestContainer';
-import { Checkbox } from './';
+import { Checkbox, CheckboxTheme } from './';
 
 class CheckboxVisual extends React.Component<any> {
   render() {
@@ -59,7 +59,7 @@ const tests = [
       {
         it: 'box',
         props: {
-          theme: 'box',
+          theme: CheckboxTheme.Box,
           onChange: () => {},
           label: 'Amazing',
         },
@@ -68,7 +68,7 @@ const tests = [
         it: 'suffix',
         props: {
           suffix: '$50,000',
-          theme: 'box',
+          theme: CheckboxTheme.Box,
           onChange: () => {},
           label: 'Amazing',
         },

--- a/src/components/Checkbox/Checkbox.visual.tsx
+++ b/src/components/Checkbox/Checkbox.visual.tsx
@@ -59,7 +59,7 @@ const tests = [
       {
         it: 'box',
         props: {
-          box: true,
+          theme: 'box',
           onChange: () => {},
           label: 'Amazing',
         },
@@ -68,7 +68,7 @@ const tests = [
         it: 'suffix',
         props: {
           suffix: '$50,000',
-          box: true,
+          theme: 'box',
           onChange: () => {},
           label: 'Amazing',
         },

--- a/src/components/Checkbox/docs/CheckboxExtendedExample.st.css
+++ b/src/components/Checkbox/docs/CheckboxExtendedExample.st.css
@@ -1,12 +1,13 @@
 :import {
-    -st-from: "../Checkbox.st.css";
-    -st-default: TPACheckbox;
+  -st-from: "../Checkbox.st.css";
+  -st-default: TPACheckbox;
 }
 
 .root {
-    -st-mixin: TPACheckbox(
-            TextColor '"--textColor"',
-            BorderColor '"--borderColor"',
-            IconColor '"--iconColor"'
-    );
+  -st-mixin: TPACheckbox(
+    TextColor '"--textColor"',
+    IconColor '"--iconColor"',
+    BoxColor '"--boxColor"',
+    BoxBorderColor '"--boxBorderColor"'
+  );
 }

--- a/src/components/Checkbox/docs/CheckboxExtendedExample.st.css
+++ b/src/components/Checkbox/docs/CheckboxExtendedExample.st.css
@@ -6,6 +6,7 @@
 .root {
   -st-mixin: TPACheckbox(
     TextColor '"--textColor"',
+    BorderColor '"--borderColor"',
     IconColor '"--iconColor"',
     BoxColor '"--boxColor"',
     BoxBorderColor '"--boxBorderColor"'

--- a/src/components/Checkbox/docs/CheckboxExtendedExample.tsx
+++ b/src/components/Checkbox/docs/CheckboxExtendedExample.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Checkbox } from '../index';
+import { Checkbox, CheckboxTheme } from '../index';
 import { classes } from './CheckboxExtendedExample.st.css';
 
 export const CheckboxExtendedExample = () => {
@@ -13,6 +13,16 @@ export const CheckboxExtendedExample = () => {
           checked={value}
           onChange={({ checked }) => setValue(checked)}
           label={value ? 'Hakol tov!' : 'Click me, ah sheli!'}
+          className={classes.root}
+        />
+      </div>
+      <div>
+        <h3>Checkbox with Box</h3>
+        <Checkbox
+          theme={CheckboxTheme.Box}
+          checked={value}
+          onChange={({ checked }) => setValue(checked)}
+          label={value ? 'Wrapped with box!' : 'Still wrapped!'}
           className={classes.root}
         />
       </div>

--- a/src/components/Checkbox/docs/CheckboxExtendedExample.tsx
+++ b/src/components/Checkbox/docs/CheckboxExtendedExample.tsx
@@ -22,7 +22,7 @@ export const CheckboxExtendedExample = () => {
           theme={CheckboxTheme.Box}
           checked={value}
           onChange={({ checked }) => setValue(checked)}
-          label={value ? 'Wrapped with box!' : 'Still wrapped!'}
+          label={value ? 'Still wrapped!' : 'Wrapped with box!'}
           className={classes.root}
         />
       </div>

--- a/src/components/Checkbox/docs/examples.ts
+++ b/src/components/Checkbox/docs/examples.ts
@@ -21,17 +21,23 @@ export const exampleWithIndeterminate = `
 `;
 
 export const exampleWithBox = `
-<Checkbox box onChange={val => console.log(val)} label="What's in the box?" />
+<Checkbox theme="box" onChange={val => console.log(val)} label="What's in the box?" />
 `;
 
 export const exampleWithCheckedBox = `
-<Checkbox box checked onChange={val => console.log(val)} label="A checkbox!" />
+<Checkbox theme="box" checked onChange={val => console.log(val)} label="A checkbox!" />
 `;
 
 export const exampleWithDisabledCheckedBox = `
-<Checkbox box checked disabled onChange={val => console.log(val)} label="I'm a disabled, checked box 😶" />
+<Checkbox theme="box" checked disabled onChange={val => console.log(val)} label="I'm a disabled, checked box 😶" />
 `;
 
-export const exampleWithSuffix = `
-<Checkbox box suffix="$1,000" onChange={val => console.log(val)} label="An expansive checkbox." />
+export const exampleWithBoxAndSuffix = `
+<Checkbox theme="box" suffix="$1,000" onChange={val => console.log(val)} label="An expansive checkbox." />
+`;
+
+export const exampleWithSmallBoxAndSuffix = `
+<div style={{ width: '250px' }}>
+  <Checkbox theme="box" suffix="$10" onChange={val => console.log(val)} label="A lot of text, relatively." />
+</div>
 `;

--- a/src/components/Checkbox/docs/examples.ts
+++ b/src/components/Checkbox/docs/examples.ts
@@ -19,3 +19,15 @@ export const exampleWithDisabled = `
 export const exampleWithIndeterminate = `
 <Checkbox onChange={val => console.log(val)} indeterminate label="What should I do 🧐?" />
 `;
+
+export const exampleWithBox = `
+<Checkbox box onChange={val => console.log(val)} label="What's in the box?" />
+`;
+
+export const exampleWithCheckedBox = `
+<Checkbox box checked onChange={val => console.log(val)} label="A checkbox!" />
+`;
+
+export const exampleWithDisabledCheckedBox = `
+<Checkbox box checked disabled onChange={val => console.log(val)} label="I'm a disabled, checked box 😶" />
+`;

--- a/src/components/Checkbox/docs/examples.ts
+++ b/src/components/Checkbox/docs/examples.ts
@@ -32,6 +32,6 @@ export const exampleWithDisabledCheckedBox = `
 <Checkbox box checked disabled onChange={val => console.log(val)} label="I'm a disabled, checked box 😶" />
 `;
 
-export const exampleWithPrice = `
-<Checkbox box price="$1,000" onChange={val => console.log(val)} label="An expansive checkbox." />
+export const exampleWithSuffix = `
+<Checkbox box suffix="$1,000" onChange={val => console.log(val)} label="An expansive checkbox." />
 `;

--- a/src/components/Checkbox/docs/examples.ts
+++ b/src/components/Checkbox/docs/examples.ts
@@ -31,3 +31,7 @@ export const exampleWithCheckedBox = `
 export const exampleWithDisabledCheckedBox = `
 <Checkbox box checked disabled onChange={val => console.log(val)} label="I'm a disabled, checked box 😶" />
 `;
+
+export const exampleWithPrice = `
+<Checkbox box price="$1,000" onChange={val => console.log(val)} label="An expansive checkbox." />
+`;

--- a/src/components/Checkbox/docs/index.story.tsx
+++ b/src/components/Checkbox/docs/index.story.tsx
@@ -101,18 +101,23 @@ export default {
               params: {
                 colors: [
                   {
-                    label: 'Icon/Box Color',
+                    label: 'Icon Color',
                     wixParam: 'iconColor',
                     defaultColor: 'color-8',
                   },
                   {
-                    label: 'Border Color',
-                    wixParam: 'borderColor',
+                    label: 'Text Color',
+                    wixParam: 'textColor',
                     defaultColor: 'color-5',
                   },
                   {
-                    label: 'Text Color',
-                    wixParam: 'textColor',
+                    label: 'Box Color',
+                    wixParam: 'boxColor',
+                    defaultColor: 'color-1',
+                  },
+                  {
+                    label: 'Box Border Color',
+                    wixParam: 'boxBorderColor',
                     defaultColor: 'color-5',
                   },
                 ],

--- a/src/components/Checkbox/docs/index.story.tsx
+++ b/src/components/Checkbox/docs/index.story.tsx
@@ -22,6 +22,40 @@ import { CheckboxExtendedExample } from './CheckboxExtendedExample';
 const code = config =>
   baseCode({ components: allComponents, compact: true, ...config });
 
+const codeExamples = [
+  { title: 'Default', source: examples.example },
+  {
+    title: 'Checked',
+    source: examples.exampleWithChecked,
+  },
+  { title: 'Error state', source: examples.exampleWithError },
+  { title: 'Disabled state', source: examples.exampleWithDisabled },
+  {
+    title: 'With indeterminate state',
+    source: examples.exampleWithIndeterminate,
+  },
+  {
+    title: 'With box',
+    source: examples.exampleWithBox,
+  },
+  {
+    title: 'With checked box',
+    source: examples.exampleWithCheckedBox,
+  },
+  {
+    title: 'With disabled, checked box',
+    source: examples.exampleWithDisabledCheckedBox,
+  },
+  {
+    title: 'With box and suffix',
+    source: examples.exampleWithBoxAndSuffix,
+  },
+  {
+    title: 'With small box and suffix',
+    source: examples.exampleWithSmallBoxAndSuffix,
+  },
+];
+
 export default {
   category: 'Components',
   storyName: 'Checkbox',
@@ -48,50 +82,7 @@ export default {
 
           title('Examples'),
 
-          ...[{ title: 'Default', source: examples.example }].map(code),
-
-          ...[
-            {
-              title: 'Checked',
-              source: examples.exampleWithChecked,
-            },
-          ].map(code),
-          ...[{ title: 'Error state', source: examples.exampleWithError }].map(
-            code,
-          ),
-          ...[
-            { title: 'Disabled state', source: examples.exampleWithDisabled },
-          ].map(code),
-          ...[
-            {
-              title: 'With indeterminate state',
-              source: examples.exampleWithIndeterminate,
-            },
-          ].map(code),
-          ...[
-            {
-              title: 'With box',
-              source: examples.exampleWithBox,
-            },
-          ].map(code),
-          ...[
-            {
-              title: 'With checked box',
-              source: examples.exampleWithCheckedBox,
-            },
-          ].map(code),
-          ...[
-            {
-              title: 'With disabled, checked box',
-              source: examples.exampleWithDisabledCheckedBox,
-            },
-          ].map(code),
-          ...[
-            {
-              title: 'With suffix',
-              source: examples.exampleWithSuffix,
-            },
-          ].map(code),
+          ...codeExamples.map(code),
         ],
       }),
 

--- a/src/components/Checkbox/docs/index.story.tsx
+++ b/src/components/Checkbox/docs/index.story.tsx
@@ -86,6 +86,12 @@ export default {
               source: examples.exampleWithDisabledCheckedBox,
             },
           ].map(code),
+          ...[
+            {
+              title: 'With price',
+              source: examples.exampleWithPrice,
+            },
+          ].map(code),
         ],
       }),
 

--- a/src/components/Checkbox/docs/index.story.tsx
+++ b/src/components/Checkbox/docs/index.story.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Checkbox } from '../';
+import { Checkbox, CheckboxTheme } from '../';
 import * as examples from './examples';
 import {
   header,
@@ -65,7 +65,7 @@ export default {
     'data-hook': 'storybook-Checkbox',
   }),
   exampleProps: {
-    //
+    theme: Object.values(CheckboxTheme),
   },
   dataHook: 'storybook-Checkbox',
   sections: [
@@ -101,7 +101,7 @@ export default {
               params: {
                 colors: [
                   {
-                    label: 'Icon Color',
+                    label: 'Icon/Box Color',
                     wixParam: 'iconColor',
                     defaultColor: 'color-8',
                   },

--- a/src/components/Checkbox/docs/index.story.tsx
+++ b/src/components/Checkbox/docs/index.story.tsx
@@ -88,8 +88,8 @@ export default {
           ].map(code),
           ...[
             {
-              title: 'With price',
-              source: examples.exampleWithPrice,
+              title: 'With suffix',
+              source: examples.exampleWithSuffix,
             },
           ].map(code),
         ],

--- a/src/components/Checkbox/docs/index.story.tsx
+++ b/src/components/Checkbox/docs/index.story.tsx
@@ -68,6 +68,24 @@ export default {
               source: examples.exampleWithIndeterminate,
             },
           ].map(code),
+          ...[
+            {
+              title: 'With box',
+              source: examples.exampleWithBox,
+            },
+          ].map(code),
+          ...[
+            {
+              title: 'With checked box',
+              source: examples.exampleWithCheckedBox,
+            },
+          ].map(code),
+          ...[
+            {
+              title: 'With disabled, checked box',
+              source: examples.exampleWithDisabledCheckedBox,
+            },
+          ].map(code),
         ],
       }),
 

--- a/src/components/Checkbox/docs/index.story.tsx
+++ b/src/components/Checkbox/docs/index.story.tsx
@@ -106,6 +106,11 @@ export default {
                     defaultColor: 'color-8',
                   },
                   {
+                    label: 'Border Color',
+                    wixParam: 'borderColor',
+                    defaultColor: 'color-5',
+                  },
+                  {
                     label: 'Text Color',
                     wixParam: 'textColor',
                     defaultColor: 'color-5',

--- a/src/components/CheckboxGroup/CheckboxGroup.driver.ts
+++ b/src/components/CheckboxGroup/CheckboxGroup.driver.ts
@@ -4,6 +4,7 @@ import {
 } from 'wix-ui-test-utils/base-driver';
 import { UniDriver } from 'wix-ui-test-utils/unidriver';
 import { checkboxDriverFactory } from '../Checkbox/Checkbox.driver';
+import { CHECKBOX_DATA_HOOKS } from '../Checkbox/dataHooks';
 
 export interface CheckboxGroupDriver extends BaseUniDriver {
   isCheckboxesExist(): Promise<boolean>;
@@ -15,6 +16,7 @@ export const checkboxGroupDriverFactory = (
   base: UniDriver,
 ): CheckboxGroupDriver => {
   const checkboxDriver = checkboxDriverFactory(base);
+  const checkboxDatahook = `[data-hook="${CHECKBOX_DATA_HOOKS.CheckboxWrapper}"]`;
 
   return {
     ...baseUniDriverFactory(base),
@@ -22,7 +24,7 @@ export const checkboxGroupDriverFactory = (
       return checkboxDriver.exists();
     },
     async isCheckboxesDisabled() {
-      const checkboxes = base.$$('label');
+      const checkboxes = base.$$(checkboxDatahook);
       const filtered = checkboxes.filter(async checkbox => {
         const cd = checkboxDriverFactory(checkbox);
 
@@ -32,7 +34,7 @@ export const checkboxGroupDriverFactory = (
       return (await checkboxes.count()) === (await filtered.count());
     },
     async isCheckboxesErrored() {
-      const checkboxes = base.$$('label');
+      const checkboxes = base.$$(checkboxDatahook);
       const filtered = checkboxes.filter(async checkbox => {
         const cd = checkboxDriverFactory(checkbox);
 


### PR DESCRIPTION
I added a wrapper box for the checkbox, and an optional price prop. I thought about calling the price property 'suffix' instead, but in the [UI docs for the radio button](https://zeroheight.com/7sjjzhgo2/p/05a744-05-selections/b/743582) they explicitly say the suffix has to be a price.

I also fixed a bug with the disabled prop not being propagated to CoreCheckbox.