### PR TITLE
fix time type styles priorities

### DIFF
--- a/src/components/CalendarCell/CalendarCell.st.css
+++ b/src/components/CalendarCell/CalendarCell.st.css
@@ -102,14 +102,6 @@
     -st-mixin: TPAText(MainTextColor value(CurrentPastFontColor), MainTextFont value(CurrentFontStyle));
 }
 
-.root:timeType(today) {
-    border-color: value(CurrentTodayColor);
-}
-
-.root:timeType(today) .title {
-    -st-mixin: TPAText(MainTextColor value(CurrentTodayColor), MainTextFont value(CurrentFontStyle));
-}
-
 .root:timeType(futureDate){
     background: value(CurrentFutureBackgroundColor);
 }
@@ -124,6 +116,14 @@
 
 .root:current .title {
     -st-mixin: TPAText(MainTextColor value(CurrentFontColor), MainTextFont value(CurrentFontStyle));
+}
+
+.root:timeType(today) {
+    border-color: value(CurrentTodayColor);
+}
+
+.root:timeType(today) .title {
+    -st-mixin: TPAText(MainTextColor value(CurrentTodayColor), MainTextFont value(CurrentFontStyle));
 }
 
 .root:stretchable {


### PR DESCRIPTION
if a type was only "today" with the current prop set to true, date color didn't got the today color