### PR TITLE
Remove hover in mobile mode for ColorPicker

### DIFF
--- a/src/components/ColorPicker/ColorPicker.st.css
+++ b/src/components/ColorPicker/ColorPicker.st.css
@@ -16,6 +16,7 @@
     border: 0;
     padding: 0.01em 0 0 0;
     min-width: 0;
+    user-select: none;
 }
 
 .wrapper {

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -15,6 +15,7 @@ interface ColorPickerProps extends TPAComponentProps {
   /** aria-label - Accessibility */
   'aria-label'?: string;
   'aria-labeledby'?: string;
+  /** The group name for all color options */
   name?: string;
 }
 

--- a/src/components/ColorPicker/ColorPickerItem/ColorPickerItem.tsx
+++ b/src/components/ColorPicker/ColorPickerItem/ColorPickerItem.tsx
@@ -68,6 +68,20 @@ export class ColorPickerItem extends React.Component<
     return radioVisual;
   };
 
+  getFocusOnHoverBehaviour = (isMobile: boolean) => {
+    if (isMobile) {
+      return {};
+    }
+    return {
+      onHover: () => {
+        this.setState({ focused: true });
+      },
+      onIconBlur: () => {
+        this.setState({ focused: false });
+      },
+    };
+  };
+
   render = () => {
     const { focused } = this.state;
     const {
@@ -112,8 +126,7 @@ export class ColorPickerItem extends React.Component<
               mobile,
             )}
             onChange={onChange}
-            onHover={() => this.setState({ focused: true })}
-            onIconBlur={() => this.setState({ focused: false })}
+            {...this.getFocusOnHoverBehaviour(mobile)}
             name={name}
           />
         )}

--- a/src/components/ColorPicker/docs/ColorPickerMobileTooltipExample.tsx
+++ b/src/components/ColorPicker/docs/ColorPickerMobileTooltipExample.tsx
@@ -21,16 +21,19 @@ export const COLORS = [
     value: 'green',
     ariaLabel: 'green color',
     disabled: true,
+    isCrossedOut: true,
     tooltip: 'Tooltip with disabled',
   },
   {
     value: 'red',
     ariaLabel: 'red color',
+    isCrossedOut: true,
     disabled: true,
   },
   {
     value: 'navy',
     ariaLabel: 'navy color',
+    tooltip: 'Tooltip Last',
   },
 ];
 
@@ -59,6 +62,7 @@ export class ColorPickerMobileTooltipExample extends React.Component<
             value={itemProps.value}
             aria-label={itemProps.ariaLabel}
             disabled={itemProps.disabled}
+            isCrossedOut={itemProps.isCrossedOut}
             tooltip={itemProps.tooltip}
             checked={this.state.selectedColor === itemProps.value}
           />


### PR DESCRIPTION
Now color options are highlighted even in disabled state. Should be not.
Also disable hover in mobile mode.