### PR TITLE
Fix dialog icon import

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -5,7 +5,7 @@ import { TPAComponentsConsumer } from '../TPAComponentsConfig';
 
 import { Modal } from '../internal/Modal';
 import { IconButton } from '../IconButton';
-import { Close as CloseIcon } from '../../assets/icons';
+import { ReactComponent as CloseIcon } from '../../assets/icons/Close.svg';
 import { TPAComponentProps } from '../../types';
 
 export interface DialogProps extends TPAComponentProps {


### PR DESCRIPTION
This import added all icons to our bundle. I think other components should not use imports from index too.