### PR TITLE
POC - support mixing internal parts only

### DIFF
--- a/src/components/Badge/Badge.st.css
+++ b/src/components/Badge/Badge.st.css
@@ -1,29 +1,11 @@
 :import {
     -st-from: "../../common/formatters.st";
-    -st-named: color, applyOpacity, fallback;
+    -st-named: color, fallback, applyOpacity;
 }
 
-:vars {
-    /*Defaults*/
-    DefaultBgColor: color-5;
-    DefaultTextColor: color-5;
-    LightBgColor: color-1;
-    LightTextColor: color-5;
-    LightBorderColor: color-5;
-    PrimaryBgColor: color-8;
-    PrimaryTextColor: color-1;
-}
-
-:vars {
-    /*Overrides*/
-    BadgeBgColor: --overridable;
-    BadgeTextColor: --overridable;
-}
-
-:vars {
-    badgeBgColor: color(fallback(value(BadgeBgColor), applyOpacity(color(value(DefaultBgColor)), 0.1)));
-    badgeTextColor: color(fallback(value(BadgeTextColor), value(DefaultTextColor)));
-    lightBorderColor: applyOpacity(color(value(LightBorderColor)), 0.10);
+:import {
+  -st-from: "./BadgeVariables.st.css";
+  -st-named: badgeBgColor, badgeTextColor, primaryBgColor, lightBgColor, primaryTextColor, lightTextColor, lightBorderColor;
 }
 
 .root {
@@ -67,12 +49,12 @@
 }
 
 .root:priority(default) .icon path {
-    fill: color(value(badgeTextColor));
+    fill: value(badgeTextColor);
 }
 
 .root:priority(light) {
-    background-color: color(value(LightBgColor));
-    color: color(value(LightTextColor));
+    background-color: value(lightBgColor);
+    color: value(lightTextColor);
     border-color: value(lightBorderColor);
     box-sizing: border-box;
     border-width: 1px;
@@ -81,19 +63,41 @@
 }
 
 .root:priority(light) .icon path {
-    fill: color(value(LightTextColor));
+    fill: value(lightTextColor);
 }
 
 .root:priority(primary) {
-    background-color: color(value(PrimaryBgColor));
-    color: color(value(PrimaryTextColor));
+    background-color: value(primaryBgColor);
+    color: value(primaryTextColor);
     border: none;
 }
 
 .root:priority(primary) .icon path {
-    fill: color(value(PrimaryTextColor));
+    fill: value(primaryTextColor);
 }
 
 .root:withIcon::before {
     width: 10px;
+}
+
+/* 
+* The ".overrides" class is not an internal parts of the component,
+* but rather to be an easy way to import and mix the overridable parts of the component.
+*/
+.overrides {
+  -st-extends: root;
+}
+
+.overrides:priority(default) {
+    background-color: value(badgeBgColor);
+    color: value(badgeTextColor);
+}
+
+.overrides:priority(default) {
+    background-color: value(badgeBgColor);
+    color: value(badgeTextColor);
+}
+
+.overrides:priority(default) .icon path {
+    fill: value(badgeTextColor);
 }

--- a/src/components/Badge/BadgeVariables.st.css
+++ b/src/components/Badge/BadgeVariables.st.css
@@ -1,0 +1,27 @@
+:import {
+    -st-from: "../../common/formatters.st";
+    -st-named: color, applyOpacity, fallback;
+}
+
+:vars {
+    /* Defaults */
+    bgColor: applyOpacity(color(color-5), 0.1);
+    primaryBgColor: color(color-8);
+    lightBgColor: color(color-1);
+    textColor: color(color-5);
+    primaryTextColor: color(color-1);
+    lightTextColor: color(color-5);
+    lightBorderColor: applyOpacity(color(color-5), 0.10);
+}
+
+:vars {
+    /* Overrides */
+    BadgeBgColor: --overridable;
+    BadgeTextColor: --overridable;
+}
+
+:vars {
+    /* Overriden values with default fallbacks */
+    badgeBgColor: color(fallback(value(BadgeBgColor), value(bgColor)));
+    badgeTextColor: color(fallback(value(BadgeTextColor), value(textColor)));
+}

--- a/src/components/Badge/docs/BadgeExtendedExample.st.css
+++ b/src/components/Badge/docs/BadgeExtendedExample.st.css
@@ -1,12 +1,13 @@
 :import {
     -st-from: "../Badge.st.css";
     -st-default: TPABadge;
+    -st-named: overrides;
 }
 
 .root {
-    -st-mixin: TPABadge(
+    -st-extends: TPABadge;
+    -st-mixin: overrides(
         BadgeBgColor '"color(--badgeBgColor)"',
         BadgeTextColor '"color(--badgeTextColor)"',
-        BadgeBorderColor '"color(--badgeBorderColor)"'
     );
 }


### PR DESCRIPTION
### What
This PR is another attempt to achieve a smaller bundle size when mixing the component.

### How
The suggested solution means refactoring the component in a way that the overridable parts are defined only to a certain class and sub-selectors.

It introduces an `overrides` class that extends the component and can be mixed

### How does it improve performance
Consumers who mix only this part will benefit from much smaller duplication since it doesn't need to duplicate selectors that are not customizable.

### Can we do better?
A more performant way will be to split this part into a separate file (e.g. `BadgeVariants.st.css`).
However, it will require some more work since it means the consumers will need to import the override styles from a different file and not from the component's .st.css file.

### Any reasons not to improve it?
Splitting the overrides to a different file means it's not backward compatible which is a bummer since it requires a major version.

### Usage
#### Current way (bad):
```css
:import {
    -st-from: 'wix-ui-tpa/dist/src/components/Badge/Badge.st.css';
    -st-default: TPABadge;
}

.root {
    -st-extends: TPABadge;
    -st-mixin: TPABadge(
        BadgeBgColor '"color(--badgeBgColor)"',
        BadgeTextColor '"color(--badgeTextColor)"',
    );
```

####  Better:
```css
:import {
    -st-from: 'wix-ui-tpa/dist/src/components/Badge/Badge.st.css';
    -st-default: TPABadge;
    -st-named: overrides;
}

.root {
    -st-extends: TPABadge;
    -st-mixin: overrides(
        BadgeBgColor '"color(--badgeBgColor)"',
        BadgeTextColor '"color(--badgeTextColor)"',
    );
}
```

####  Best (not implemented yet):
```css
:import {
    -st-from: 'wix-ui-tpa/dist/src/components/Badge/Badge.st.css';
    -st-default: TPABadge;
}

:import {
    -st-from: 'wix-ui-tpa/dist/src/components/Badge/BadgeOverrides.st.css';
    -st-default: TPABadgeOverrides;
}

.root {
    -st-extends: TPABadge;
    -st-mixin: TPABadgeOverrides(
        BadgeBgColor '"color(--badgeBgColor)"',
        BadgeTextColor '"color(--badgeTextColor)"',
    );
}
```

### Numbers:
I created a really small app that all it does is this:
```js
import React from 'react';
import { Badge } from 'wix-ui-tpa/dist/src/components/Badge';
import { classes } from './App.st.css';

class App extends React.Component {
  render() {
    return <Badge className={classes.badge}>hello</Badge>;
  }
}

export default App;
```

```css
:import {
  -st-from: 'wix-ui-tpa/dist/src/components/Badge/Badge.st.css';
  -st-default: Badge;
  -st-named: overrides;
}

//before
.badge {
  -st-extends: Badge;
  -st-mixin: Badge(
    BadgeBgColor yellow
  );
}

//after
.badge {
  -st-extends: Badge;
  -st-mixin: overrides(
    BadgeBgColor yellow
  );
}

```

All the code (both styles and js code) are bundled to the JS file for simplicity. the output numbers were this:

Before (mix the entire Badge):
  **10.8 KB  (2.93 KB GZIP)**  dist/statics/app.bundle.min.js

After (mix only the overrides):
  **9.28 KB  (2.83 KB GZIP)**  dist/statics/app.bundle.min.js

Yes, it's only 1.72kb, which is not a big difference, but think about much more complex stylesheets there are. Every kb counts!

### More general possible optimizations?
1. Make smaller class names (if name optimization is not done on the webpack side)
2. Ditch style states which creates long selectors (e.g. change `.root:priority(primary):skin(dark)....` to `.root.primary.dark`, in the end css it's smaller)
3. Split variations to different styles and mix them on the consumer side (e.g. change `<Badge priority="secondary"/>` to -st-mixin of the relevant variation)