### PR TITLE
<Counter> fix layout on IE11

### DIFF
--- a/src/components/Counter/Counter.st.css
+++ b/src/components/Counter/Counter.st.css
@@ -82,7 +82,7 @@
 }
 
 .root .inputWrapper {
-    flex-grow: 1;
+    flex: 1;
 }
 
 .root input {


### PR DESCRIPTION
Currently the counter looks like that on IE11: ![image](https://user-images.githubusercontent.com/6060495/97804480-eafbc380-1c58-11eb-9450-8c8e47c1d8a7.png)
It seems that flex-grow isn't supported well on IE11.

This is how it looks after the fix:
![image](https://user-images.githubusercontent.com/6060495/97804546-59408600-1c59-11eb-86c9-26a8275647d3.png)
