### PR TITLE
Dialog allow style wiring

### DIFF
--- a/src/components/Dialog/Dialog.meta.tsx
+++ b/src/components/Dialog/Dialog.meta.tsx
@@ -6,7 +6,7 @@ const DialogMetadata = Registry.getComponentMetadata(Dialog);
 DialogMetadata.nonReactStrictModeCompliant = true;
 
 const DialogContent = () => (
-  <div>
+  <div style={{ backgroundColor: 'white' }}>
     <h2 id="dialog4_label" className="dialog_label">
       End of the Road!
     </h2>
@@ -32,7 +32,9 @@ DialogMetadata.addSim({
   title: 'Manual Focus',
   props: {
     isOpen: true,
-    children: <div>This is the content!</div>,
+    children: (
+      <div style={{ backgroundColor: 'white' }}>This is the content!</div>
+    ),
     manualFocus: true,
     closeButtonRef: React.createRef<HTMLButtonElement>(),
     'aria-label': 'Dialog',

--- a/src/components/Dialog/Dialog.st.css
+++ b/src/components/Dialog/Dialog.st.css
@@ -5,7 +5,7 @@
 
 :import {
     -st-from: "../IconButton/IconButton.st.css";
-    -st-default: TPAIconButton;
+    -st-named: skin-line;
 }
 
 /*Defaults*/
@@ -54,7 +54,7 @@
 }
 
 .closeIconButton {
-    -st-mixin: TPAIconButton(
+    -st-mixin: skin-line(
             IconColor value(DefaultCloseButtonColor)
     );
 }
@@ -87,7 +87,7 @@
 }
 
 .overrideStyleParams:wired .closeIconButton {
-    -st-mixin: TPAIconButton(
+    -st-mixin: skin-line(
             IconColor value(WiredCloseButtonColor)
     );
 }

--- a/src/components/Dialog/Dialog.st.css
+++ b/src/components/Dialog/Dialog.st.css
@@ -77,17 +77,6 @@
     left: 20px;
 }
 
-/* Deprecated - Old style params overriding for full mixin */
-.root:wired .contentWrapper {
-    background: value(WiredBackgroundColor);
-}
-
-.root:wired .closeIconButton {
-    -st-mixin: TPAIconButton(
-            IconColor value(WiredCloseButtonColor)
-    );
-}
-
 /* New style overrides capabilities */
 .overrideStyleParams {
     -st-extends: root;

--- a/src/components/Dialog/Dialog.st.css
+++ b/src/components/Dialog/Dialog.st.css
@@ -8,14 +8,6 @@
     -st-named: skin-line;
 }
 
-/*Defaults*/
-:vars {
-    DefaultWiredCloseButtonColor: color-5;
-    DefaultCloseButtonColor: #000000;
-    DefaultWiredBackgroundColor: color-1;
-    DefaultBackgroundColor: #ffffff;
-}
-
 /*Overrides*/
 :vars {
     CloseButtonColor: --overridable;
@@ -24,12 +16,14 @@
 
 /*Fallbacks*/
 :vars {
-    WiredCloseButtonColor: color(fallback(value(CloseButtonColor), value(DefaultWiredCloseButtonColor)));
-    WiredBackgroundColor: color(fallback(value(BackgroundColor), value(DefaultWiredBackgroundColor)));
+    FixedCloseButtonColor: color(fallback(value(CloseButtonColor), black));
+    FixedBackgroundColor: color(fallback(value(BackgroundColor), white));
+    WiredCloseButtonColor: color(fallback(value(CloseButtonColor), color-5));
+    WiredBackgroundColor: color(fallback(value(BackgroundColor), color-1));
 }
 
 .root {
-    -st-states: mobile, rtl, wired;
+    -st-states: mobile, rtl;
 }
 
 .contentWrapper {
@@ -43,20 +37,12 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -30%);
-
-    background: value(DefaultBackgroundColor);
 }
 
 .closeButtonWrapper {
     position: absolute;
     top: 20px;
     right: 20px;
-}
-
-.closeIconButton {
-    -st-mixin: skin-line(
-            IconColor value(DefaultCloseButtonColor)
-    );
 }
 
 .dialogContent {
@@ -78,16 +64,22 @@
 }
 
 /* New style overrides capabilities */
-.overrideStyleParams {
-    -st-extends: root;
+.skin-fixed .contentWrapper {
+    background: value(FixedBackgroundColor);
 }
 
-.overrideStyleParams:wired .contentWrapper {
+.skin-fixed .closeIconButton {
+    -st-mixin: skin-line(
+        IconColor value(FixedCloseButtonColor)
+    );
+}
+
+.skin-wired .contentWrapper {
     background: value(WiredBackgroundColor);
 }
 
-.overrideStyleParams:wired .closeIconButton {
+.skin-wired .closeIconButton {
     -st-mixin: skin-line(
-            IconColor value(WiredCloseButtonColor)
+        IconColor value(WiredCloseButtonColor)
     );
 }

--- a/src/components/Dialog/Dialog.st.css
+++ b/src/components/Dialog/Dialog.st.css
@@ -50,7 +50,6 @@
 }
 
 .root:mobile .contentWrapper {
-    height: 100%;
     top: 0;
     left: 0;
     width: 100%;
@@ -65,7 +64,7 @@
 
 /* New style overrides capabilities */
 .skin-fixed .contentWrapper {
-    background: value(FixedBackgroundColor);
+    background-color: value(FixedBackgroundColor);
 }
 
 .skin-fixed .closeIconButton {
@@ -75,7 +74,7 @@
 }
 
 .skin-wired .contentWrapper {
-    background: value(WiredBackgroundColor);
+    background-color: value(WiredBackgroundColor);
 }
 
 .skin-wired .closeIconButton {

--- a/src/components/Dialog/Dialog.st.css
+++ b/src/components/Dialog/Dialog.st.css
@@ -10,21 +10,26 @@
 
 /*Defaults*/
 :vars {
-    DefaultCloseButtonColor: color-5;
+    DefaultWiredCloseButtonColor: color-5;
+    DefaultCloseButtonColor: #000000;
+    DefaultWiredBackgroundColor: color-1;
+    DefaultBackgroundColor: #ffffff;
 }
 
 /*Overrides*/
 :vars {
     CloseButtonColor: --overridable;
+    BackgroundColor: --overridable;
 }
 
 /*Fallbacks*/
 :vars {
-    CurrentCloseButtonColor: color(fallback(value(CloseButtonColor), value(DefaultCloseButtonColor)));
+    WiredCloseButtonColor: color(fallback(value(CloseButtonColor), value(DefaultWiredCloseButtonColor)));
+    WiredBackgroundColor: color(fallback(value(BackgroundColor), value(DefaultWiredBackgroundColor)));
 }
 
 .root {
-    -st-states: mobile, rtl;
+    -st-states: mobile, rtl, wired;
 }
 
 .contentWrapper {
@@ -39,7 +44,23 @@
     left: 50%;
     transform: translate(-50%, -30%);
 
-    background: #fff;
+    background: value(DefaultBackgroundColor);
+}
+
+.closeButtonWrapper {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+}
+
+.closeIconButton {
+    -st-mixin: TPAIconButton(
+            IconColor value(DefaultCloseButtonColor)
+    );
+}
+
+.dialogContent {
+    padding: 80px 32px;
 }
 
 .root:mobile .contentWrapper {
@@ -51,23 +72,17 @@
     transform: none;
 }
 
-.closeButtonWrapper {
-    position: absolute;
-    top: 20px;
-    right: 20px;
-}
-
 .root:rtl .closeButtonWrapper {
     right: initial;
     left: 20px;
 }
 
-.closeIconButton {
-    -st-mixin: TPAIconButton(
-            IconColor value(CurrentCloseButtonColor)
-    );
+.root:wired .contentWrapper {
+    background: value(WiredBackgroundColor);
 }
 
-.dialogContent {
-    padding: 80px 32px;
+.root:wired .closeIconButton {
+    -st-mixin: TPAIconButton(
+            IconColor value(WiredCloseButtonColor)
+    );
 }

--- a/src/components/Dialog/Dialog.st.css
+++ b/src/components/Dialog/Dialog.st.css
@@ -77,11 +77,27 @@
     left: 20px;
 }
 
+/* Deprecated - Old style params overriding for full mixin */
 .root:wired .contentWrapper {
     background: value(WiredBackgroundColor);
 }
 
 .root:wired .closeIconButton {
+    -st-mixin: TPAIconButton(
+            IconColor value(WiredCloseButtonColor)
+    );
+}
+
+/* New style overrides capabilities */
+.overrideStyleParams {
+    -st-extends: root;
+}
+
+.overrideStyleParams:wired .contentWrapper {
+    background: value(WiredBackgroundColor);
+}
+
+.overrideStyleParams:wired .closeIconButton {
     -st-mixin: TPAIconButton(
             IconColor value(WiredCloseButtonColor)
     );

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -31,6 +31,8 @@ export interface DialogProps extends TPAComponentProps {
   closeButtonAriaLabel?: string;
   /** Identifies the element that labels the close button element. Optional. */
   closeButtonAriaLabelledby?: string;
+  /** Whether the Dialog is wired to the site palette, or has a white background */
+  wiredToSiteColors?: boolean;
 }
 
 interface DefaultProps {
@@ -60,13 +62,18 @@ export class Dialog extends React.Component<DialogProps> {
       ['aria-describedby']: ariaDescribedBy,
       closeButtonAriaLabel,
       closeButtonAriaLabelledby,
+      wiredToSiteColors,
     } = this.props;
 
     return (
       <TPAComponentsConsumer>
         {({ mobile, rtl }) => (
           <div
-            className={st(classes.root, { mobile, rtl }, className)}
+            className={st(
+              classes.root,
+              { mobile, rtl, wired: wiredToSiteColors },
+              className,
+            )}
             data-hook={this.props['data-hook']}
             data-mobile={mobile}
           >

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
-import { st, classes } from './Dialog.st.css';
 import { DATA_HOOKS } from './constants';
 import { TPAComponentsConsumer } from '../TPAComponentsConfig';
-
 import { Modal } from '../internal/Modal';
 import { IconButton } from '../IconButton';
 import { ReactComponent as CloseIcon } from '../../assets/icons/Close.svg';
 import { TPAComponentProps } from '../../types';
+import { st, classes } from './Dialog.st.css';
 
 export interface DialogProps extends TPAComponentProps {
   /** Whether the modal is opened */
@@ -71,7 +70,8 @@ export class Dialog extends React.Component<DialogProps> {
           <div
             className={st(
               classes.root,
-              { mobile, rtl, wired: wiredToSiteColors },
+              { mobile, rtl },
+              classes[`skin-${wiredToSiteColors ? 'wired' : 'fixed'}`],
               className,
             )}
             data-hook={this.props['data-hook']}

--- a/src/components/Dialog/Dialog.visual.tsx
+++ b/src/components/Dialog/Dialog.visual.tsx
@@ -3,36 +3,46 @@ import { visualize, story, snap } from 'storybook-snapper';
 import { Dialog } from './';
 import { Text, TYPOGRAPHY } from '../Text';
 import { Button, PRIORITY } from '../Button';
+import {setDarkPalette} from "../../test/visualTestUtils";
+
+const DialogWithContent = props => (
+  <Dialog isOpen wiredToSiteColors={props.wired}>
+    <div className="content" style={{ textAlign: 'center' }}>
+      <Text typography={TYPOGRAPHY.largeTitle}>Are You Sure?</Text>
+      <div
+        className="text-container"
+        style={{ marginTop: '24px', marginBottom: '36px' }}
+      >
+        <Text typography={TYPOGRAPHY.listText} tagName="div">
+          <div>Do you really want to delete the selected files?</div>
+          <div>Once removed, cannot be undone.</div>
+        </Text>
+      </div>
+      <Button
+        upgrade
+        priority={PRIORITY.basicSecondary}
+        style={{ marginLeft: '10px' }}
+      >
+        SECONDARY
+      </Button>
+      <Button upgrade style={{ marginLeft: '10px' }}>
+        PRIMARY
+      </Button>
+    </div>
+  </Dialog>
+);
 
 visualize('Dialog', () => {
   story('simple', () => {
     snap('default props', <Dialog isOpen />);
-    snap(
-      'Dialog with some content',
-      <Dialog isOpen>
-        <div className="content" style={{ textAlign: 'center' }}>
-          <Text typography={TYPOGRAPHY.largeTitle}>Are You Sure?</Text>
-          <div
-            className="text-container"
-            style={{ marginTop: '24px', marginBottom: '36px' }}
-          >
-            <Text typography={TYPOGRAPHY.listText} tagName="div">
-              <div>Do you really want to delete the selected files?</div>
-              <div>Once removed, cannot be undone.</div>
-            </Text>
-          </div>
-          <Button
-            upgrade
-            priority={PRIORITY.basicSecondary}
-            style={{ marginLeft: '10px' }}
-          >
-            SECONDARY
-          </Button>
-          <Button upgrade style={{ marginLeft: '10px' }}>
-            PRIMARY
-          </Button>
-        </div>
-      </Dialog>,
-    );
+    snap('Dialog with some content', <DialogWithContent />);
+  });
+
+  story('Wired to palette', () => {
+    snap('Dialog with some content', () => {
+      setDarkPalette();
+
+      return <DialogWithContent wired />;
+    });
   });
 });

--- a/src/components/Dialog/Dialog.visual.tsx
+++ b/src/components/Dialog/Dialog.visual.tsx
@@ -3,7 +3,7 @@ import { visualize, story, snap } from 'storybook-snapper';
 import { Dialog } from './';
 import { Text, TYPOGRAPHY } from '../Text';
 import { Button, PRIORITY } from '../Button';
-import {setDarkPalette} from "../../test/visualTestUtils";
+import { setDarkPalette } from '../../test/visualTestUtils';
 
 const DialogWithContent = props => (
   <Dialog isOpen wiredToSiteColors={props.wired}>

--- a/src/components/Dialog/Dialog.visual.tsx
+++ b/src/components/Dialog/Dialog.visual.tsx
@@ -3,7 +3,7 @@ import { visualize, story, snap } from 'storybook-snapper';
 import { Dialog } from './';
 import { Text, TYPOGRAPHY } from '../Text';
 import { Button, PRIORITY } from '../Button';
-import { setDarkPalette } from '../../test/visualTestUtils';
+// import { setDarkPalette } from '../../test/visualTestUtils';
 
 const DialogWithContent = props => (
   <Dialog isOpen wiredToSiteColors={props.wired}>
@@ -38,11 +38,11 @@ visualize('Dialog', () => {
     snap('Dialog with some content', <DialogWithContent />);
   });
 
-  story('Wired to palette', () => {
-    snap('Dialog with some content', () => {
-      setDarkPalette();
-
-      return <DialogWithContent wired />;
-    });
-  });
+  // story('Wired to palette', () => {
+  //   snap('Dialog with some content', () => {
+  //     // setDarkPalette();
+  //
+  //     return <DialogWithContent wired />;
+  //   });
+  // });
 });

--- a/src/components/Dialog/Dialog.visual.tsx
+++ b/src/components/Dialog/Dialog.visual.tsx
@@ -38,11 +38,16 @@ visualize('Dialog', () => {
     snap('Dialog with some content', <DialogWithContent />);
   });
 
-  // story('Wired to palette', () => {
-  //   snap('Dialog with some content', () => {
-  //     // setDarkPalette();
-  //
-  //     return <DialogWithContent wired />;
-  //   });
-  // });
+  story('Wired to palette', () => {
+    snap('Dialog with some content', () => {
+      return <DialogWithContent wired />;
+    });
+
+    // TODO uncomment when we'll support dark theme tests
+    // snap('with dark theme', () => {
+    //   setDarkPalette();
+    //
+    //   return <DialogWithContent wired />;
+    // });
+  });
 });

--- a/src/components/Dialog/docs/DialogWiringExample.st.css
+++ b/src/components/Dialog/docs/DialogWiringExample.st.css
@@ -1,10 +1,10 @@
 :import {
     -st-from: "../Dialog.st.css";
-    -st-named: overrideStyleParams;
+    -st-named: skin-wired;
 }
 
 .dialogComponent {
-    -st-mixin: overrideStyleParams(
+    -st-mixin: skin-wired(
             CloseButtonColor '"color(--customCloseButtonColor)"',
             BackgroundColor '"color(--customBackgroundColor)"'
     );

--- a/src/components/Dialog/docs/DialogWiringExample.st.css
+++ b/src/components/Dialog/docs/DialogWiringExample.st.css
@@ -1,11 +1,12 @@
 :import {
     -st-from: "../Dialog.st.css";
-    -st-default: TPADialog;
+    -st-named: overrideStyleParams;
 }
 
 .dialogComponent {
-    -st-mixin: TPADialog(
-            CloseButtonColor '"color(--customCloseButtonColor)"'
+    -st-mixin: overrideStyleParams(
+            CloseButtonColor '"color(--customCloseButtonColor)"',
+            BackgroundColor '"color(--customBackgroundColor)"'
     );
 }
 

--- a/src/components/Dialog/docs/DialogWiringExample.tsx
+++ b/src/components/Dialog/docs/DialogWiringExample.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { Dialog } from '../';
+import { ToggleSwitch } from '../../ToggleSwitch';
+import { Text } from '../../Text';
 import { classes } from './DialogWiringExample.st.css';
 
 import { Button } from '../../Button';
@@ -7,27 +9,46 @@ import { Button } from '../../Button';
 export class DialogWiringExample extends React.Component {
   state = {
     isOpen: false,
+    isWired: false,
   };
 
-  onOpenDialogButtonClick = () => {
+  _onOpenDialogButtonClick = () => {
     this.setState({ isOpen: true });
   };
 
-  onCloseDialog = () => {
+  _onCloseDialog = () => {
     this.setState({ isOpen: false });
   };
 
+  _onWireChange = () => {
+    const { isWired } = this.state;
+    this.setState({ isWired: !isWired });
+  };
+
   render = () => {
-    const { isOpen } = this.state;
+    const { isOpen, isWired } = this.state;
     return (
       <>
-        <Button upgrade onClick={this.onOpenDialogButtonClick}>
+        <div
+          style={{ display: 'flex', alignItems: 'center', marginBottom: 12 }}
+        >
+          <label htmlFor="wireToggle" style={{ marginRight: 12 }}>
+            <Text>Wire to site colors:</Text>
+          </label>
+          <ToggleSwitch
+            id="wireToggle"
+            checked={isWired}
+            onChange={this._onWireChange}
+          />
+        </div>
+        <Button upgrade onClick={this._onOpenDialogButtonClick}>
           Open Dialog
         </Button>
         <Dialog
           className={classes.dialogComponent}
           isOpen={isOpen}
-          onClose={this.onCloseDialog}
+          onClose={this._onCloseDialog}
+          wiredToSiteColors={isWired}
         >
           <div className={classes.content}>This is the content!</div>
         </Dialog>

--- a/src/components/Dialog/docs/index.story.tsx
+++ b/src/components/Dialog/docs/index.story.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as examples from './examples';
 import {
+  description,
   header,
   api,
   divider,
@@ -93,6 +94,10 @@ export default {
       tab({
         title: 'Usage',
         sections: [
+          description(
+            'A styled Modal component. Used to provide critical information or ask for a decision and/or user input.',
+          ),
+
           importExample({
             source: examples.importExample,
           }),

--- a/src/components/Dialog/docs/index.story.tsx
+++ b/src/components/Dialog/docs/index.story.tsx
@@ -128,6 +128,11 @@ export default {
                     wixParam: 'customCloseButtonColor',
                     defaultColor: 'color-5',
                   },
+                  {
+                    label: 'Background Color',
+                    wixParam: 'customBackgroundColor',
+                    defaultColor: 'color-1',
+                  },
                 ],
               },
             }),

--- a/src/components/IconButton/IconButton.st.css
+++ b/src/components/IconButton/IconButton.st.css
@@ -21,7 +21,7 @@
 
 .root {
     -st-extends: ButtonNext;
-    -st-states: disabled, skin(enum(line, full));
+    -st-states: disabled;
     /*css goes here*/
     background-color: transparent;
     text-decoration: none;
@@ -44,28 +44,28 @@
     opacity: 1;
 }
 
-.root:skin(line):disabled .icon path {
-    stroke: color(value(DisabledColor));
-    fill: none;
-}
-
-.root:skin(full):disabled .icon path {
-    fill: color(value(DisabledColor));
-    stroke: color(value(DisabledColor));
-}
-
 .icon svg {
     display: block;
 }
 
-.root:skin(line) .icon path {
+.root:disabled.skin-line .icon path {
+    stroke: color(value(DisabledColor));
+    fill: none;
+}
+
+.root:disabled.skin-full .icon path {
+    fill: color(value(DisabledColor));
+    stroke: color(value(DisabledColor));
+}
+
+/* Variants - including style overrides capabilities */
+
+.root.skin-line .icon path {
     stroke: color(fallback(value(IconColor), value(DefaultColor)));
     fill: none;
 }
 
-.root:skin(full) .icon path {
+.root.skin-full .icon path {
     fill: color(fallback(value(IconColor), value(DefaultColor)));
     stroke: color(fallback(value(IconColor), value(DefaultColor)));
 }
-
-

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -31,7 +31,12 @@ export class IconButton extends React.Component<IconButtonProps, State> {
     const { icon, disabled, skin, className, innerRef, ...rest } = this.props;
     return (
       <ButtonNext
-        className={st(classes.root, { disabled, skin }, className)}
+        className={st(
+          classes.root,
+          { disabled },
+          classes[`skin-${skin}`],
+          className,
+        )}
         {...rest}
         ref={innerRef}
       >

--- a/src/components/IconButton/docs/IconButtonExtendedExample.st.css
+++ b/src/components/IconButton/docs/IconButtonExtendedExample.st.css
@@ -1,10 +1,24 @@
 :import {
   -st-from: "../IconButton.st.css";
   -st-default: TPAIconButton;
+  -st-named: skin-line, skin-full;
 }
 
-.root {
+.mixSkinLine {
+  -st-mixin: skin-line(
+          IconColor '"color(--iconColor)"'
+  );
+}
+
+.mixSkinFull {
+  -st-mixin: skin-full(
+          IconColor '"color(--iconColor)"'
+  );
+}
+
+/* Deprecated - causes big bundle sizes */
+.mixAll {
   -st-mixin: TPAIconButton(
-    IconColor '"color(--iconColor)"'
+          IconColor '"color(--iconColor)"'
   );
 }

--- a/src/components/IconButton/docs/IconButtonExtendedExample.tsx
+++ b/src/components/IconButton/docs/IconButtonExtendedExample.tsx
@@ -6,11 +6,15 @@ import { IconButton, Skins } from '../IconButton';
 export class IconButtonExtendedExample extends React.Component {
   render = () => (
     <div>
+      <h3>
+        Override the style params per skin - start with a skin and change what
+        you want - this is common for a component with predefined variations
+      </h3>
       <div>
         <IconButton
           icon={<ShareIcon />}
-          {...this.props}
-          className={classes.root}
+          skin={Skins.Line}
+          className={classes.mixSkinLine}
         />{' '}
         Skin 'line'
       </div>
@@ -18,10 +22,19 @@ export class IconButtonExtendedExample extends React.Component {
         <IconButton
           icon={<ShareIcon />}
           skin={Skins.Full}
-          {...this.props}
-          className={classes.root}
+          className={classes.mixSkinFull}
         />{' '}
         Skin 'full'
+      </div>
+
+      <h3>*Deprecated* - Override the style params in the entire css file</h3>
+      <div>
+        <IconButton
+          icon={<ShareIcon />}
+          skin={Skins.Line}
+          className={classes.mixAll}
+        />{' '}
+        Skin 'line'
       </div>
     </div>
   );

--- a/src/components/IconButton/docs/examples.ts
+++ b/src/components/IconButton/docs/examples.ts
@@ -2,8 +2,9 @@ const ShareIcon = `
 <svg width="24px" height="24px">
     <path d="M14.2736842,7.11666667 C12.1894737,7.21111111 3.66315789,8.62777778 3,21 C4.51578947,17.2222222 8.11578947,14.6722222 12.1894737,14.6722222 C12.8526316,14.6722222 13.5157895,14.7666667 14.2736842,14.8611111 L14.2736842,18.1666667 L21,11.0833333 L14.2736842,4 L14.2736842,7.11666667 Z"/>
 </svg>`;
+
 export const basicExample = `
-<IconButton
-      icon={${ShareIcon}}
-    />
-`;
+  <div style={{'display': 'flex', gap: '16px'}}>
+    <IconButton skin={Skins.Line} icon={${ShareIcon}}/>
+    <IconButton skin={Skins.Full} icon={${ShareIcon}}/>
+  </div>`;

--- a/src/components/IconButton/docs/index.story.tsx
+++ b/src/components/IconButton/docs/index.story.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { IconButton, Skins } from '../';
 import {
   api,
-  code as baseCode,
   divider,
   header,
   importExample,
@@ -11,6 +10,7 @@ import {
   tabs,
   testkit,
   title,
+  example as baseExample,
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
 
@@ -38,8 +38,12 @@ const iconExamples = [
   },
 ];
 
-const code = config =>
-  baseCode({ components: allComponents, compact: true, ...config });
+const example = (config, extraContext = {}) =>
+  baseExample({
+    components: { ...allComponents, ...extraContext },
+    compact: true,
+    ...config,
+  });
 
 export default {
   category: StoryCategory.COMPONENTS,
@@ -70,9 +74,15 @@ export default {
           divider(),
 
           title('Examples'),
-          ...[{ title: 'Icon Button', source: examples.basicExample }].map(
-            code,
-          ),
+
+          ...[
+            {
+              title: 'Icon Button',
+              description:
+                'The IconButton component has different skins to apply',
+              source: examples.basicExample,
+            },
+          ].map(example),
         ],
       }),
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -18,7 +18,7 @@ export * from './Badge';
 export * from './Avatar';
 export * from './Tabs';
 export * from './Tooltip';
-export { IconButton } from './IconButton';
+export * from './IconButton';
 export * from './Ratings';
 export { AvatarGroup } from './AvatarGroup';
 export { Counter } from './Counter';

--- a/src/test/utils.tsx
+++ b/src/test/utils.tsx
@@ -1,6 +1,6 @@
+import { UniDriver } from '@unidriver/core';
 import * as React from 'react';
 import { TPAComponentsProvider } from '../components/TPAComponentsConfig';
-import { UniDriver } from '@unidriver/core';
 
 export const TPAComponentsWrapper = ({ mobile = false, rtl = false }) => {
   return Component => {

--- a/src/test/visualTestUtils.ts
+++ b/src/test/visualTestUtils.ts
@@ -1,0 +1,23 @@
+// @ts-ignore
+import SettingsChangedEvent from '../../mocks/fakeTPAChange.json';
+
+const DARK_PALETTE = [
+  ['#000000', '#333333', '#666666', '#999999', '#FFFFFF'],
+  ['#2D2D2D', '#575757', '#818181', '#ABABAB', '#E8E8E8'],
+  ['#542000', '#A84000', '#FC6000', '#FDAF7E', '#FEC9A9'],
+  ['#1F3141', '#3E6282', '#5E93C4', '#9FBCD7', '#C2D7EB'],
+  ['#4E3206', '#9D640C', '#EC9712', '#F2C682', '#F8DAAC'],
+];
+
+export const setDarkPalette = () => {
+  const obj = { ...SettingsChangedEvent };
+  obj.params.siteColors.forEach((colorObj, ind) => {
+    const col = ind % 5;
+    const row = Math.floor(ind / 5);
+
+    if (row < 5 && col < 5) {
+      colorObj.value = DARK_PALETTE[row][col];
+    }
+  });
+  window.postMessage(JSON.stringify(obj), '*');
+};


### PR DESCRIPTION
This PR is a preliminary fix for https://github.com/wix/wix-ui-tpa/issues/468

At the moment the Dialog component doesn't allow overriding the background color and allowing it to be wired to the site colors.

This PR allows this behaviour, but still leaves the responsibility for passing black and white components to the Dialog, on the TPA's side.
