### PR TITLE
docs: simulate focus ring

### DIFF
--- a/.storybook/addons/FocusRingToggle/index.js
+++ b/.storybook/addons/FocusRingToggle/index.js
@@ -1,0 +1,21 @@
+import addons, { makeDecorator } from '@storybook/addons';
+import * as React from 'react';
+import { ADDON_ID, ADDON_TITLE } from './shared';
+import { useState } from 'react';
+import FocusRing from '../../../stories/helperComponents/FocusRing';
+
+const FocusRingToggle = makeDecorator({
+  name: ADDON_TITLE,
+  parameterName: ADDON_TITLE,
+  allowDeprecatedUsage: true,
+  wrapper: (getStory) => {
+    const [active, setActive] = useState(false);
+    const channel = addons.getChannel();
+
+    channel.on(ADDON_ID + '/change', (params) => setActive(params.active));
+
+    return <FocusRing active={active}>{getStory()}</FocusRing>;
+  },
+});
+
+export default FocusRingToggle;

--- a/.storybook/addons/FocusRingToggle/register.js
+++ b/.storybook/addons/FocusRingToggle/register.js
@@ -1,0 +1,35 @@
+import React, { useState, useEffect } from 'react';
+import addons, { types } from '@storybook/addons';
+import { useChannel } from '@storybook/api';
+import { ADDON_ID, ADDON_TITLE, PANEL_ID } from './shared';
+
+function FocusRingToggleButton() {
+  const [active, setActive] = useState(false);
+  const emit = useChannel({});
+  useEffect(() => emit(ADDON_ID + '/change', { active }));
+
+  return (
+    <div
+      style={{
+        margin: 'auto 15px',
+        cursor: 'pointer',
+        userSelect: 'none',
+        padding: '3px 8px',
+        backgroundColor: active ? '#4EB7F5' : '#eee',
+        color: active ? '#444' : '#999',
+      }}
+      onClick={() => setActive(!active)}
+    >
+      Focus Ring
+    </div>
+  );
+}
+
+addons.register(ADDON_ID, (api) => {
+  addons.add(PANEL_ID, {
+    type: types.TOOL,
+    title: ADDON_TITLE,
+    match: ({ viewMode }) => viewMode === 'story',
+    render: () => <FocusRingToggleButton />,
+  });
+});

--- a/.storybook/addons/FocusRingToggle/shared.js
+++ b/.storybook/addons/FocusRingToggle/shared.js
@@ -1,0 +1,3 @@
+export const ADDON_TITLE = 'FocusRingToggle';
+export const ADDON_ID = `storybooks/${ADDON_TITLE}`;
+export const PANEL_ID = `${ADDON_ID}/panel`;

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,6 +1,7 @@
-import { configure, addParameters } from '@storybook/react';
+import { configure, addParameters, addDecorator } from '@storybook/react';
 import styleProcessor from 'wix-style-processor';
 import { storySort } from './utils';
+import FocusRingToggle from './addons/FocusRingToggle';
 
 function loadStories() {
   require('../stories');
@@ -22,6 +23,8 @@ addParameters({
     storySort,
   },
 });
+
+addDecorator(FocusRingToggle);
 
 configureStorybook();
 

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,0 +1,3 @@
+module.exports = {
+  addons: [__dirname + '/addons/FocusRingToggle/register.js'],
+};

--- a/.storybook/stories.scss
+++ b/.storybook/stories.scss
@@ -15,8 +15,3 @@ body {
   color: "color(color-5)";
   background-color: "color(color-1)";
 }
-
-*:focus {
-  box-shadow: 0 0 0 1px #ffffff, 0 0 0 3px #116dff !important;
-  z-index: 999,
-}

--- a/.storybook/stories.scss
+++ b/.storybook/stories.scss
@@ -17,5 +17,6 @@ body {
 }
 
 *:focus {
-  box-shadow: 0 0 0 1px #ffffff, 0 0 0 3px #116dff;
+  box-shadow: 0 0 0 1px #ffffff, 0 0 0 3px #116dff !important;
+  z-index: 999,
 }

--- a/.storybook/stories.scss
+++ b/.storybook/stories.scss
@@ -15,3 +15,7 @@ body {
   color: "color(color-5)";
   background-color: "color(color-1)";
 }
+
+*:focus {
+  box-shadow: 0 0 0 1px #ffffff, 0 0 0 3px #116dff;
+}

--- a/stories/helperComponents/FocusRing.st.css
+++ b/stories/helperComponents/FocusRing.st.css
@@ -1,4 +1,8 @@
-.root *:focus {
+.root {
+  -st-states: active;
+}
+
+.root:active *:focus {
   box-shadow: 0 0 0 1px #ffffff, 0 0 0 3px #116dff !important;
   z-index: 999;
 }

--- a/stories/helperComponents/FocusRing.st.css
+++ b/stories/helperComponents/FocusRing.st.css
@@ -1,0 +1,4 @@
+.root *:focus {
+  box-shadow: 0 0 0 1px #ffffff, 0 0 0 3px #116dff !important;
+  z-index: 999;
+}

--- a/stories/helperComponents/FocusRing.tsx
+++ b/stories/helperComponents/FocusRing.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { st, classes } from './FocusRing.st.css';
+
+export interface FocusRingProps extends React.PureComponent {
+  active: boolean;
+}
+
+export default class extends React.PureComponent<FocusRingProps> {
+  render() {
+    const { active, children } = this.props;
+
+    return <div className={st(active ? classes.root : null)}>{children}</div>;
+  }
+}

--- a/stories/helperComponents/FocusRing.tsx
+++ b/stories/helperComponents/FocusRing.tsx
@@ -9,6 +9,6 @@ export default class extends React.PureComponent<FocusRingProps> {
   render() {
     const { active, children } = this.props;
 
-    return <div className={st(active ? classes.root : null)}>{children}</div>;
+    return <div className={st(classes.root, { active })}>{children}</div>;
   }
 }


### PR DESCRIPTION
This PR simulates the viewer's focus-ring by adding the relevant style globally.

Basically it does what TB does, but the following selector sounds redundant for the StoryBook environment:
`#SITE_CONTAINER.focus-ring-active :not(.has-custom-focus):not(.ignore-focus):focus, #SITE_CONTAINER.focus-ring-active :not(.has-custom-focus):not(.ignore-focus):focus ~ .wixSdkShowFocusOnSibling': {`

It also affects Storybook elements, but I don't think it's an issue. We can restrict it somehow to the component preview if it bothers...