### PR TITLE
docs: add style api tab

### DIFF
--- a/src/components/ActionsMenuLayout/docs/index.story.tsx
+++ b/src/components/ActionsMenuLayout/docs/index.story.tsx
@@ -16,21 +16,15 @@ import {
 import { allComponents } from '../../../../stories/utils/allComponents';
 import { ReactComponent as ShareIcon } from '../../../assets/icons/Share.svg';
 import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import * as ExtendedRawSource from '!raw-loader!./ActionsMenuLayoutExtendedExample.tsx';
 import * as ExtendedCSSRawSource from '!raw-loader!./ActionsMenuLayoutExtendedExample.st.css';
 import { ActionsMenuLayoutExtendedExample } from './ActionsMenuLayoutExtendedExample';
 
-const code = config =>
-  baseCode({ components: allComponents, compact: true, ...config });
+const code = (config) => baseCode({ components: allComponents, compact: true, ...config });
 
 function generateItem(props) {
-  return (
-    <ActionsMenuLayout.Item
-      key={props.content}
-      onClick={() => alert('click')}
-      {...props}
-    />
-  );
+  return <ActionsMenuLayout.Item key={props.content} onClick={() => alert('click')} {...props} />;
 }
 
 export default {
@@ -95,6 +89,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
         {

--- a/src/components/ActionsMenuLayout/docs/index.story.tsx
+++ b/src/components/ActionsMenuLayout/docs/index.story.tsx
@@ -21,10 +21,17 @@ import * as ExtendedRawSource from '!raw-loader!./ActionsMenuLayoutExtendedExamp
 import * as ExtendedCSSRawSource from '!raw-loader!./ActionsMenuLayoutExtendedExample.st.css';
 import { ActionsMenuLayoutExtendedExample } from './ActionsMenuLayoutExtendedExample';
 
-const code = (config) => baseCode({ components: allComponents, compact: true, ...config });
+const code = config =>
+  baseCode({ components: allComponents, compact: true, ...config });
 
 function generateItem(props) {
-  return <ActionsMenuLayout.Item key={props.content} onClick={() => alert('click')} {...props} />;
+  return (
+    <ActionsMenuLayout.Item
+      key={props.content}
+      onClick={() => alert('click')}
+      {...props}
+    />
+  );
 }
 
 export default {

--- a/src/components/AddItem/docs/index.story.tsx
+++ b/src/components/AddItem/docs/index.story.tsx
@@ -14,6 +14,7 @@ import {
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
 import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import * as AddItemWiringExampleRaw from '!raw-loader!./AddItemWiringExample.tsx';
 import * as AddItemWiringExampleCSSRaw from '!raw-loader!./AddItemWiringExample.st.css';
 import { AddItemWiringExample } from './AddItemWiringExample';
@@ -65,6 +66,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
         {

--- a/src/components/Avatar/docs/index.story.tsx
+++ b/src/components/Avatar/docs/index.story.tsx
@@ -14,6 +14,7 @@ import {
   title,
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import { AvatarSize } from '../Avatar';
 
 const code = config =>
@@ -59,6 +60,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
       ].map(tab),

--- a/src/components/AvatarGroup/docs/index.story.tsx
+++ b/src/components/AvatarGroup/docs/index.story.tsx
@@ -17,6 +17,7 @@ import {
 import { allComponents } from '../../../../stories/utils/allComponents';
 import { AvatarGroupSize } from '../AvatarGroup';
 import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import * as ExtendedRawSource from '!raw-loader!./ExtendedExample.tsx';
 import * as ExtendedCSSRawSource from '!raw-loader!./ExtendedExample.st.css';
 import { ExtendedExample } from './ExtendedExample';
@@ -81,6 +82,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
         {

--- a/src/components/Button/docs/index.story.tsx
+++ b/src/components/Button/docs/index.story.tsx
@@ -20,6 +20,7 @@ import * as ExtendedCSSRawWithStyleParams from '!raw-loader!./ButtonExtendedWith
 import { examples } from './examples';
 import { ButtonExtendedWithStyleParamsExample } from './ButtonExtendedWithStyleParamsExample';
 import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 
 import { Button, PRIORITY, SIZE } from '..';
 
@@ -66,6 +67,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
         {

--- a/src/components/CalendarCell/docs/index.story.tsx
+++ b/src/components/CalendarCell/docs/index.story.tsx
@@ -14,6 +14,7 @@ import {
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
 import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import * as CalendarCellWiringExampleRaw from '!raw-loader!./CalendarCellWiringExample.tsx';
 import * as CalendarCellWiringExampleCSSRaw from '!raw-loader!./CalendarCellWiringExample.st.css';
 import { CalendarCellWiringExample } from './CalendarCellWiringExample';
@@ -57,6 +58,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
         {

--- a/src/components/CalendarPopover/docs/index.story.tsx
+++ b/src/components/CalendarPopover/docs/index.story.tsx
@@ -14,6 +14,7 @@ import {
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
 import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import * as CalendarPopoverWiringExampleRaw from '!raw-loader!./CalendarPopoverWiringExample.tsx';
 import * as CalendarPopoverWiringExampleCSSRaw from '!raw-loader!./CalendarPopoverWiringExample.st.css';
 import { CalendarPopoverWiringExample } from './CalendarPopoverWiringExample';
@@ -97,6 +98,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
         {

--- a/src/components/Card/docs/index.story.tsx
+++ b/src/components/Card/docs/index.story.tsx
@@ -21,6 +21,7 @@ import * as ExtendedRawSource from '!raw-loader!./CardExtendedExample.tsx';
 import * as ExtendedCSSRawSource from '!raw-loader!./CardExtendedExample.st.css';
 import { CardExtendedExample } from './CardExtendedExample';
 import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 
 const code = config =>
   baseCode({ components: allComponents, compact: true, ...config });
@@ -107,6 +108,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
         {

--- a/src/components/Checkbox/docs/index.story.tsx
+++ b/src/components/Checkbox/docs/index.story.tsx
@@ -15,6 +15,7 @@ import {
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
 import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import * as ExtendedRawSource from '!raw-loader!./CheckboxExtendedExample.tsx';
 import * as ExtendedCSSRawSource from '!raw-loader!./CheckboxExtendedExample.st.css';
 import { CheckboxExtendedExample } from './CheckboxExtendedExample';
@@ -88,6 +89,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
         {

--- a/src/components/CheckboxGroup/docs/index.story.tsx
+++ b/src/components/CheckboxGroup/docs/index.story.tsx
@@ -15,6 +15,7 @@ import {
   title,
 } from 'wix-storybook-utils/Sections';
 import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import { allComponents } from '../../../../stories/utils/allComponents';
 import * as ExtendedRawSource from '!raw-loader!./CheckboxGroupExtendedExample.tsx';
 import * as ExtendedCSSRawSource from '!raw-loader!./CheckboxGroupExtendedExample.st.css';
@@ -86,6 +87,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
         {

--- a/src/components/ColorPicker/docs/index.story.tsx
+++ b/src/components/ColorPicker/docs/index.story.tsx
@@ -16,6 +16,7 @@ import {
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
 import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import {
   ColorPickerExtendedExample,
   COLORS,
@@ -105,6 +106,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
         {

--- a/src/components/CopyUrlButton/docs/index.story.tsx
+++ b/src/components/CopyUrlButton/docs/index.story.tsx
@@ -14,6 +14,7 @@ import {
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
 import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import * as CopyUrlButtonWiringExampleRaw from '!raw-loader!./CopyUrlButtonWiringExample.tsx';
 import * as CopyUrlButtonWiringExampleCSSRaw from '!raw-loader!./CopyUrlButtonWiringExample.st.css';
 import { CopyUrlButtonWiringExample } from './CopyUrlButtonWiringExample';
@@ -60,6 +61,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
         {

--- a/src/components/Counter/docs/index.story.tsx
+++ b/src/components/Counter/docs/index.story.tsx
@@ -14,6 +14,7 @@ import {
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
 import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import * as ExtendedRawSource from '!raw-loader!./CounterExtendedExample.tsx';
 import * as ExtendedCSSRawSource from '!raw-loader!./CounterExtendedExample.st.css';
 import { CounterExtendedExample } from './CounterExtendedExample';
@@ -79,6 +80,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
         {

--- a/src/components/Dialog/docs/index.story.tsx
+++ b/src/components/Dialog/docs/index.story.tsx
@@ -14,6 +14,7 @@ import {
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
 import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import * as DialogWiringExampleRaw from '!raw-loader!./DialogWiringExample.tsx';
 import * as DialogWiringExampleCSSRaw from '!raw-loader!./DialogWiringExample.st.css';
 import { DialogWiringExample } from './DialogWiringExample';
@@ -107,6 +108,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
         {

--- a/src/components/DotNavigation/docs/index.story.tsx
+++ b/src/components/DotNavigation/docs/index.story.tsx
@@ -15,6 +15,7 @@ import {
   description,
 } from 'wix-storybook-utils/Sections';
 import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import { allComponents } from '../../../../stories/utils/allComponents';
 import * as ExtendedRawSource from '!raw-loader!./DotNavigationExtendedExample.tsx';
 import * as ExtendedCSSRawSource from '!raw-loader!./DotNavigationExtendedExample.st.css';
@@ -76,6 +77,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
         {

--- a/src/components/Dropdown/docs/index.story.tsx
+++ b/src/components/Dropdown/docs/index.story.tsx
@@ -13,6 +13,7 @@ import {
   title,
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import { Dropdown } from '../';
 import { DROPDOWN_ALIGNMENT } from '../Dropdown';
 import {
@@ -127,6 +128,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
       ].map(tab),

--- a/src/components/Event/docs/index.story.tsx
+++ b/src/components/Event/docs/index.story.tsx
@@ -14,6 +14,7 @@ import {
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
 import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import * as EventWiringExampleRaw from '!raw-loader!./EventWiringExample.tsx';
 import * as EventWiringExampleCSSRaw from '!raw-loader!./EventWiringExample.st.css';
 import { EventWiringExample } from './EventWiringExample';
@@ -61,6 +62,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
         {

--- a/src/components/FloatingDropdown/docs/index.story.tsx
+++ b/src/components/FloatingDropdown/docs/index.story.tsx
@@ -14,6 +14,7 @@ import {
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
 import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import * as FloatingDropdownWiringExampleRaw from '!raw-loader!./FloatingDropdownWiringExample.tsx';
 import * as FloatingDropdownWiringExampleCSSRaw from '!raw-loader!./FloatingDropdownWiringExample.st.css';
 import { FloatingDropdownWiringExample } from './FloatingDropdownWiringExample';
@@ -68,6 +69,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
         {

--- a/src/components/Grid/docs/index.story.tsx
+++ b/src/components/Grid/docs/index.story.tsx
@@ -14,6 +14,7 @@ import {
   title,
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import { Card } from '../../Card';
 import { Text } from '../../Text';
 
@@ -107,6 +108,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
       ].map(tab),

--- a/src/components/IconButton/docs/index.story.tsx
+++ b/src/components/IconButton/docs/index.story.tsx
@@ -17,6 +17,7 @@ import { allComponents } from '../../../../stories/utils/allComponents';
 import { ReactComponent as ShareIcon } from '../../../assets/icons/Share.svg';
 import { ReactComponent as HeartIcon } from '../../../assets/icons/Heart.svg';
 import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import * as ExtendedRawSource from '!raw-loader!./IconButtonExtendedExample.tsx';
 import * as ExtendedCSSRawSource from '!raw-loader!./IconButtonExtendedExample.st.css';
 import { IconButtonExtendedExample } from './IconButtonExtendedExample';
@@ -75,6 +76,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
         {

--- a/src/components/IconToggle/docs/index.story.tsx
+++ b/src/components/IconToggle/docs/index.story.tsx
@@ -12,6 +12,7 @@ import {
   testkit,
   title,
 } from 'wix-storybook-utils/Sections';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import { ReactComponent as StarIcon } from '../../../assets/icons/Star.svg';
 import { ReactComponent as HeartIcon } from '../../../assets/icons/Heart.svg';
 
@@ -65,6 +66,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
       ].map(tab),

--- a/src/components/Image/docs/index.story.tsx
+++ b/src/components/Image/docs/index.story.tsx
@@ -12,6 +12,7 @@ import {
 } from 'wix-storybook-utils/Sections';
 import { Image } from '../';
 import { allComponents } from '../../../../stories/utils/allComponents';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import * as examples from './examples';
 
 const code = config =>
@@ -78,6 +79,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
       ].map(tab),

--- a/src/components/LikeButton/docs/index.story.tsx
+++ b/src/components/LikeButton/docs/index.story.tsx
@@ -13,6 +13,7 @@ import {
   title,
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import Examples from './extendedExamples';
 
 const code = config =>
@@ -52,6 +53,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
       ].map(tab),

--- a/src/components/OverlappingCard/docs/index.story.tsx
+++ b/src/components/OverlappingCard/docs/index.story.tsx
@@ -14,6 +14,7 @@ import {
   title,
 } from 'wix-storybook-utils/Sections';
 
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import Examples from './exampleWithSettingPanel';
 import { OverlappingCard, OverlappingCardRatioOptions } from '../';
 import { Button } from '../../Button';
@@ -87,6 +88,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
       ].map(tab),

--- a/src/components/Pagination/docs/index.story.tsx
+++ b/src/components/Pagination/docs/index.story.tsx
@@ -13,6 +13,7 @@ import {
   title,
 } from 'wix-storybook-utils/Sections';
 
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import { Pagination } from '../Pagination';
 import { Examples } from './Examples';
 
@@ -53,6 +54,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
       ].map(tab),

--- a/src/components/Picker/docs/index.story.tsx
+++ b/src/components/Picker/docs/index.story.tsx
@@ -14,6 +14,7 @@ import {
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
 import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import * as PickerWiringExampleRaw from '!raw-loader!./PickerWiringExample.tsx';
 import * as PickerWiringExampleCSSRaw from '!raw-loader!./PickerWiringExample.st.css';
 import { PickerWiringExample } from './PickerWiringExample';
@@ -54,6 +55,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
         {

--- a/src/components/ProgressBar/docs/index.story.tsx
+++ b/src/components/ProgressBar/docs/index.story.tsx
@@ -14,6 +14,7 @@ import {
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
 import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import * as ProgressBarWiringExampleRaw from '!raw-loader!./ProgressBarWiringExample.tsx';
 import * as ProgressBarWiringExampleCSSRaw from '!raw-loader!./ProgressBarWiringExample.st.css';
 import { ProgressBarWiringExample } from './ProgressBarWiringExample';
@@ -64,6 +65,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
         {

--- a/src/components/RadioButton/docs/index.story.tsx
+++ b/src/components/RadioButton/docs/index.story.tsx
@@ -14,6 +14,7 @@ import {
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
 import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import * as RadioButtonWiringExampleRaw from '!raw-loader!./RadioButtonWiringExample.tsx';
 import * as RadioButtonWiringExampleCSSRaw from '!raw-loader!./RadioButtonWiringExample.st.css';
 import RadioButtonWiringExample from './RadioButtonWiringExample';
@@ -71,6 +72,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
         {

--- a/src/components/RadioButtonGroup/docs/index.story.tsx
+++ b/src/components/RadioButtonGroup/docs/index.story.tsx
@@ -14,6 +14,7 @@ import {
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
 import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import * as RadioButtonGroupWiringExampleRaw from '!raw-loader!./RadioButtonGroupWiringExample.tsx';
 import * as RadioButtonGroupWiringExampleCSSRaw from '!raw-loader!./RadioButtonGroupWiringExample.st.css';
 import { RadioButtonGroupWiringExample } from './RadioButtonGroupWiringExample';
@@ -82,6 +83,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
         {

--- a/src/components/Ratings/docs/index.story.tsx
+++ b/src/components/Ratings/docs/index.story.tsx
@@ -15,6 +15,7 @@ import {
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
 import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import * as ExtendedRawSource from '!raw-loader!./RatingsExtendedExample.tsx';
 import * as ExtendedCSSRawSource from '!raw-loader!./RatingsExtendedExample.st.css';
 import { RatingsExtendedExample } from './RatingsExtendedExample';
@@ -78,6 +79,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
         {

--- a/src/components/SectionNotification/docs/index.story.tsx
+++ b/src/components/SectionNotification/docs/index.story.tsx
@@ -13,6 +13,7 @@ import {
 } from 'wix-storybook-utils/Sections';
 import { BUTTON_PRIORITY, NOTIFICATION_TYPE, SectionNotification } from '../';
 import { allComponents } from '../../../../stories/utils/allComponents';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import { ReactComponent as ErrorIcon } from '../../../assets/icons/Error.svg';
 import * as examples from './examples';
 
@@ -113,6 +114,7 @@ export default {
       }),
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
       ].map(tab),

--- a/src/components/ShareButton/docs/index.story.tsx
+++ b/src/components/ShareButton/docs/index.story.tsx
@@ -14,6 +14,7 @@ import {
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
 import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import * as ShareButtonWiringExampleRaw from '!raw-loader!./ShareButtonWiringExample.tsx';
 import * as ShareButtonWiringExampleCSSRaw from '!raw-loader!./ShareButtonWiringExample.st.css';
 import { ShareButtonWiringExample } from './ShareButtonWiringExample';
@@ -69,6 +70,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
         {

--- a/src/components/SocialBar/docs/index.story.tsx
+++ b/src/components/SocialBar/docs/index.story.tsx
@@ -14,6 +14,7 @@ import {
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
 import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import * as SocialBarWiringExampleRaw from '!raw-loader!./SocialBarWiringExample.tsx';
 import * as SocialBarWiringExampleCSSRaw from '!raw-loader!./SocialBarWiringExample.st.css';
 import { SocialBarWiringExample } from './SocialBarWiringExample';
@@ -125,6 +126,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
         {

--- a/src/components/Spinner/docs/index.story.tsx
+++ b/src/components/Spinner/docs/index.story.tsx
@@ -14,6 +14,7 @@ import {
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
 import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import * as SpinnerWiringExampleRaw from '!raw-loader!./SpinnerWiringExample.tsx';
 import * as SpinnerWiringExampleCSSRaw from '!raw-loader!./SpinnerWiringExample.st.css';
 import { SpinnerWiringExample } from './SpinnerWiringExample';
@@ -75,6 +76,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
         {

--- a/src/components/StripCard/docs/index.story.tsx
+++ b/src/components/StripCard/docs/index.story.tsx
@@ -15,6 +15,7 @@ import {
   description,
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import { Text, TYPOGRAPHY } from '../../Text';
 
 const code = config =>
@@ -105,6 +106,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
       ].map(tab),

--- a/src/components/Tags/docs/index.story.tsx
+++ b/src/components/Tags/docs/index.story.tsx
@@ -14,6 +14,7 @@ import {
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
 import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import * as TagsWiringExampleRaw from '!raw-loader!./TagsWiringExample.tsx';
 import * as TagsWiringExampleCSSRaw from '!raw-loader!./TagsWiringExample.st.css';
 import { TagsWiringExample } from './TagsWiringExample';
@@ -116,6 +117,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
         {

--- a/src/components/TextButton/docs/index.story.tsx
+++ b/src/components/TextButton/docs/index.story.tsx
@@ -18,6 +18,7 @@ import {
   title,
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import * as Readme from '../README.md';
 
 const code = config =>
@@ -59,6 +60,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
       ].map(tab),

--- a/src/components/TextField/docs/index.story.tsx
+++ b/src/components/TextField/docs/index.story.tsx
@@ -17,6 +17,7 @@ import { allComponents } from '../../../../stories/utils/allComponents';
 import * as examples from './examples';
 import { TextFieldExtendedExample } from './TextFieldExtendedExample';
 import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import * as textFieldRawSource from '!raw-loader!./TextFieldExtendedExample.tsx';
 import * as textFieldCSSRawSource from '!raw-loader!./TextFieldExtendedExample.st.css';
 import { ReactComponent as CalendarIcon } from '../../../assets/icons/Calendar.svg';
@@ -148,6 +149,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
         {

--- a/src/components/Toast/docs/index.story.tsx
+++ b/src/components/Toast/docs/index.story.tsx
@@ -15,6 +15,7 @@ import {
   title,
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import * as Readme from '../README.md';
 import { TOAST_SKIN, TOAST_PLACEMENT } from '../types';
 
@@ -72,6 +73,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
       ].map(tab),

--- a/src/components/ToggleSwitch/docs/index.story.tsx
+++ b/src/components/ToggleSwitch/docs/index.story.tsx
@@ -16,6 +16,7 @@ import {
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
 import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import * as ExtendedRawSource from '!raw-loader!./ToggleSwitchExtensionExample.tsx';
 import * as ExtendedCSSRawSource from '!raw-loader!./ToggleSwitchExtensionExample.st.css';
 import { ToggleSwitchExtensionExample } from './ToggleSwitchExtensionExample';
@@ -56,6 +57,10 @@ export default {
       tab({
         title: 'API',
         sections: [api()],
+      }),
+      tab({
+        title: 'Style API',
+        sections: [settingsApi()],
       }),
       tab({
         title: 'TestKit',

--- a/src/components/internal/Modal/docs/index.story.tsx
+++ b/src/components/internal/Modal/docs/index.story.tsx
@@ -13,6 +13,7 @@ import {
   title,
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../../stories/utils/allComponents';
+import { settingsApi } from '../../../../../stories/utils/SettingsApi';
 import { Modal as CoreModal, ModalProps } from '../index';
 import { Button } from '../../../Button';
 
@@ -125,6 +126,7 @@ export default {
 
       ...[
         { title: 'API', sections: [api()] },
+        { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
         { title: 'Playground', sections: [playground()] },
       ].map(tab),


### PR DESCRIPTION
This PR adds the "Style API" tab for most of the stories (besides the components which we need to align the `section` property completely)

These are the missing components:
Divider, NewCard, StatesButton, Tabs, Text, Tooltip