### PR TITLE
fix(Dropdown): Pass initialSelectedId to CoreDropdown when it updates…

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -94,7 +94,10 @@ export class Dropdown extends React.Component<DropdownProps, State> {
   }
 
   static getDerivedStateFromProps(nextProps, state) {
-    if (state.selectedOption) {
+    if (
+      state.selectedOption &&
+      (!nextProps.initialSelectedId || state.selectedOption.id === nextProps.initialSelectedId)
+    ) {
       return null;
     }
     return {


### PR DESCRIPTION
… as well as initially

I wanted to add tests but I can't figure out how to update initialSelectedId after setting it initially in tests, updating a variable didn't work. Example of test I want to write - 

```js
  it('should update selected id when initial selected id changes', async () => {
    const options = new Array(5).fill(null).map((el, i) => ({
      id: `${i}`,
      value: `value-${i}`,
      isSelectable: i < 3,
    }));
    let selectedId = '0';
    const driver = createDriver(
      <Dropdown options={options} initialSelectedId={selectedId} />,
    );
    expect(await driver.getDropdownText()).toEqual(options[0].value);
    selectedId = '1';
    expect(await driver.getDropdownText()).toEqual(options[1].value);
  });
```