### PR TITLE
Swimm - add walkthrough guide for supporting overrideStyleParams

### DIFF
--- a/.swm/1VbSs88wFoa6GAZdNauE.swm
+++ b/.swm/1VbSs88wFoa6GAZdNauE.swm
@@ -1,0 +1,44 @@
+{
+    "id": "1VbSs88wFoa6GAZdNauE",
+    "name": "Adding component style variables",
+    "dod": "In this unit you you will add Stylable variables for the component.",
+    "description": "In some cases, you might want to style some component different from the others. While all components are mapped to the color palette, one can decide to map specific parts differently. This is why the components expose variables allowing to customize the styles when the consumer uses `overrideStyleParams`.",
+    "summary": "",
+    "hunksOrder": [
+        "src/components/FloatingDropdown/FloatingDropdown.st.css_0"
+    ],
+    "tests": [],
+    "hints": [],
+    "play_mode": "walkthrough",
+    "swimmPatch": {
+        "src/components/FloatingDropdown/FloatingDropdown.st.css": {
+            "diffType": "MODIFIED",
+            "fileDiffHeader": "diff --git a/src/components/FloatingDropdown/FloatingDropdown.st.css b/src/components/FloatingDropdown/FloatingDropdown.st.css\nindex 04bc86a..04bc86a 100644\n--- a/src/components/FloatingDropdown/FloatingDropdown.st.css\n+++ b/src/components/FloatingDropdown/FloatingDropdown.st.css",
+            "hunks": [
+                {
+                    "swimmHunkMetadata": {
+                        "hunkComments": []
+                    },
+                    "hunkDiffLines": [
+                        "@@ -48,12 +48,6 @@",
+                        "     MainTextFont: --overridable;",
+                        " }",
+                        " ",
+                        "-:vars {",
+                        "-    ButtonTextColor: color(value(MainButtonTextColor), value(DefaultTextColor)));",
+                        "-    ItemTextColor: color(fallback(value(MainItemTextColor), value(MainButtonTextColor), value(DefaultTextColor)));",
+                        "-    DropdownBackgroundColor: color(fallback(value(MainDropdownBackgroundColor), value(DefaultDropdownBackgroundColor)));",
+                        "-    TextFont: fallback(font(value(MainTextFont)), font(value(DefaultTextFont)));",
+                        "-}",
+                        " ",
+                        " .root .dropdown {",
+                        "     min-width: value(minWidth);"
+                    ]
+                }
+            ]
+        }
+    },
+    "app_version": "0.2.8",
+    "file_version": "1.0.4",
+    "last_commit_sha_for_swimm_patch": "f2810a0b7da1430ebb7a8e8d3031856bfeb20c64"
+}

--- a/.swm/68LoNKicAoMqrlK2Jyvl.swm
+++ b/.swm/68LoNKicAoMqrlK2Jyvl.swm
@@ -1,0 +1,49 @@
+{
+    "id": "68LoNKicAoMqrlK2Jyvl",
+    "name": "Using overrideStyleParams in wiring example",
+    "dod": "In this unit you will use overrideStyleParams correctly inside the wiring example.",
+    "description": "The wiring example is the example appearing inside the Settings Panel on the story page. This example also simulates the way consumers use the component and shows exactly how to use `overrideStyleParams` in the correct way.\n\nAt first, we should import the `overrideStyleParams` mixin from the Stylable file of the component.\n\nThen, we should invoke the mixin inside `.root` of the consumed component and pass to it parameters representing the customized component variables. For example, `MainDropdownBackgroundColor` is an overridable component variable that is overriden to `--DropdownBackgroundColor`, which is a palette style.",
+    "summary": "",
+    "hunksOrder": [
+        "src/components/FloatingDropdown/docs/FloatingDropdownWiringExample.st.css_0"
+    ],
+    "tests": [],
+    "hints": [],
+    "play_mode": "walkthrough",
+    "swimmPatch": {
+        "src/components/FloatingDropdown/docs/FloatingDropdownWiringExample.st.css": {
+            "diffType": "MODIFIED",
+            "fileDiffHeader": "diff --git a/src/components/FloatingDropdown/docs/FloatingDropdownWiringExample.st.css b/src/components/FloatingDropdown/docs/FloatingDropdownWiringExample.st.css\nindex 86e2173..86e2173 100644\n--- a/src/components/FloatingDropdown/docs/FloatingDropdownWiringExample.st.css\n+++ b/src/components/FloatingDropdown/docs/FloatingDropdownWiringExample.st.css",
+            "hunks": [
+                {
+                    "swimmHunkMetadata": {
+                        "hunkComments": []
+                    },
+                    "hunkDiffLines": [
+                        "@@ -1,17 +1,4 @@",
+                        " ",
+                        "-:import {",
+                        "-    -st-from: \"../FloatingDropdown.st.css\";",
+                        "-    -st-named: overrideStyleParams;",
+                        "-}",
+                        "-",
+                        "-.root {",
+                        "-    -st-mixin: overrideStyleParams(",
+                        "-        MainDropdownBackgroundColor '\"--DropdownBackgroundColor\"',",
+                        "-        MainButtonTextColor '\"--ButtonTextColor\"',",
+                        "-        MainItemTextColor '\"--ItemTextColor\"',",
+                        "-        MainTextFont '\"--TextFont\"'",
+                        "-    );",
+                        "-}",
+                        " ",
+                        " .divider {",
+                        "     margin: 20px 0;"
+                    ]
+                }
+            ]
+        }
+    },
+    "app_version": "0.2.8",
+    "file_version": "1.0.4",
+    "last_commit_sha_for_swimm_patch": "23697c37ad83d6f1474072c859d9d3bb0644d1ce"
+}

--- a/.swm/716IERM4vXmxo7cq5a2H.swm
+++ b/.swm/716IERM4vXmxo7cq5a2H.swm
@@ -1,0 +1,56 @@
+{
+    "id": "716IERM4vXmxo7cq5a2H",
+    "name": "Exposing overrideStyleParams",
+    "dod": "In this unit you will expose `overrideStyleParams` as mixin of the component.",
+    "description": "After the component has style variables, we can use `overrideStyleParams` to make them [overridable in an optimized way](https://github.com/wix/wix-ui-tpa/blob/master/docs/USAGE.md#an-optimized-way-for-style-overriding---new) by using them inside `overrideStyleParams` selectors.\n\nWe wrap the parts of the component we want to be customized with the `overrideStyleParams` selector, and apply the style variables inside on the specific CSS property. \n\nIn this way, we expose `overrideStyleParams` as a [Stylable mixin](https://stylable.io/docs/references/mixins).",
+    "summary": "",
+    "hunksOrder": [
+        "src/components/FloatingDropdown/FloatingDropdown.st.css_0"
+    ],
+    "tests": [],
+    "hints": [],
+    "play_mode": "walkthrough",
+    "swimmPatch": {
+        "src/components/FloatingDropdown/FloatingDropdown.st.css": {
+            "diffType": "MODIFIED",
+            "fileDiffHeader": "diff --git a/src/components/FloatingDropdown/FloatingDropdown.st.css b/src/components/FloatingDropdown/FloatingDropdown.st.css\nindex 04bc86a..04bc86a 100644\n--- a/src/components/FloatingDropdown/FloatingDropdown.st.css\n+++ b/src/components/FloatingDropdown/FloatingDropdown.st.css",
+            "hunks": [
+                {
+                    "swimmHunkMetadata": {
+                        "hunkComments": []
+                    },
+                    "hunkDiffLines": [
+                        "@@ -76,24 +76,6 @@",
+                        "     -st-extends: DropdownOption;",
+                        " }",
+                        " ",
+                        "-.overrideStyleParams .dropdown::dropdownContent {",
+                        "-    background-color: value(DropdownBackgroundColor);",
+                        "-}",
+                        "-",
+                        "-.overrideStyleParams .dropdown::dropdownContent::dropdownOption:hovered,",
+                        "-.overrideStyleParams .dropdown::dropdownContent::dropdownOption:selected {",
+                        "-    background-color: applyOpacity(value(ItemTextColor), 0.06);",
+                        "-}",
+                        "-",
+                        "-.overrideStyleParams .dropdown::dropdownContent .optionDivider {",
+                        "-    background-color: value(ItemTextColor);",
+                        "-}",
+                        "-",
+                        "-.overrideStyleParams .option::title {",
+                        "-    white-space: initial;",
+                        "-    color: value(ItemTextColor);",
+                        "-    font: value(TextFont);",
+                        "-}",
+                        " ",
+                        " .floatingDropdownBase {",
+                        "     -st-extends: FloatingDropdownBase;"
+                    ]
+                }
+            ]
+        }
+    },
+    "app_version": "0.2.8",
+    "file_version": "1.0.4",
+    "last_commit_sha_for_swimm_patch": "f2810a0b7da1430ebb7a8e8d3031856bfeb20c64"
+}

--- a/.swm/dMDxOtdTreBakhqNLBHS.swm
+++ b/.swm/dMDxOtdTreBakhqNLBHS.swm
@@ -1,0 +1,45 @@
+{
+    "id": "dMDxOtdTreBakhqNLBHS",
+    "name": "Exposing overrideStyleParams with base component",
+    "dod": "In this unit you will expose `overrideStyleParams` as mixin of the component, that uses `overrideStyleParams` of base component under the hood.",
+    "description": "Sometimes the component uses a base component under the hood. In order to allow custom styles of such parts, we need to:\n1. Expose `overrideStyleParams` inside the base component as well for the overridable variables.\n2. Extend the stylesheet of the base component using `-st-extends` within an extending selector inside our component (for example, `floatingDropdownBase`).\n3. Pass this extending selector to the base component as `className` when using the render method.\n4. Expose `overrideStyleParams` inside our component making the extending selector to invoke the `overrideStyleParams` of the base component (for example `overrideStyleParamsBase`), but with the style variables of our component as parameters (for example, `MainButtonTextColor`).\n\nIn simple words - we take the overridable variables of the component and pass them to `overrideStyleParams` of the base component. This extending selector, we pass eventually to the base component when rendering it.",
+    "summary": "",
+    "hunksOrder": [
+        "src/components/FloatingDropdown/FloatingDropdown.st.css_0"
+    ],
+    "tests": [],
+    "hints": [],
+    "play_mode": "walkthrough",
+    "swimmPatch": {
+        "src/components/FloatingDropdown/FloatingDropdown.st.css": {
+            "diffType": "MODIFIED",
+            "fileDiffHeader": "diff --git a/src/components/FloatingDropdown/FloatingDropdown.st.css b/src/components/FloatingDropdown/FloatingDropdown.st.css\nindex 04bc86a..04bc86a 100644\n--- a/src/components/FloatingDropdown/FloatingDropdown.st.css\n+++ b/src/components/FloatingDropdown/FloatingDropdown.st.css",
+            "hunks": [
+                {
+                    "swimmHunkMetadata": {
+                        "hunkComments": []
+                    },
+                    "hunkDiffLines": [
+                        "@@ -95,13 +95,3 @@",
+                        "     font: value(TextFont);",
+                        " }",
+                        " ",
+                        "-.floatingDropdownBase {",
+                        "-    -st-extends: FloatingDropdownBase;",
+                        "-}",
+                        "-",
+                        "-.overrideStyleParams .floatingDropdownBase {",
+                        "-    -st-mixin: overrideStyleParamsBase(",
+                        "-        MainTextColor value(MainButtonTextColor),",
+                        "-        MainTextFont value(TextFont)",
+                        "-    );",
+                        "-}"
+                    ]
+                }
+            ]
+        }
+    },
+    "app_version": "0.2.8",
+    "file_version": "1.0.4",
+    "last_commit_sha_for_swimm_patch": "4b1e30aece32fb4353867647c5be2928a3e18c90"
+}

--- a/.swm/lTnxX1vvIAcjop54EjNb.swm
+++ b/.swm/lTnxX1vvIAcjop54EjNb.swm
@@ -1,8 +1,8 @@
 {
     "id": "lTnxX1vvIAcjop54EjNb",
-    "name": "Making styles overridable ",
-    "dod": "In this unit you should will understand how to make a Stylable variable overridable.",
-    "description": "Sometimes we allow the consumers to customize and override the style params of the component by design.",
+    "name": "Making palette styles overridable ",
+    "dod": "In this unit you should will understand how to make a Stylable variable (representing a palette style) overridable.",
+    "description": "Sometimes we allow the consumers to customize and override the style params of the palette that the component uses.",
     "summary": "",
     "hunksOrder": [
         "src/components/Dialog/Dialog.st.css_0"
@@ -39,5 +39,5 @@
     },
     "app_version": "0.2.8",
     "file_version": "1.0.4",
-    "last_commit_sha_for_swimm_patch": "719aa9b239b8c883269ebbb5299e62d4bcec6c2a"
+    "last_commit_sha_for_swimm_patch": "f2810a0b7da1430ebb7a8e8d3031856bfeb20c64"
 }

--- a/.swm/w8m40J8TlaVF5GBLxAgc.swm
+++ b/.swm/w8m40J8TlaVF5GBLxAgc.swm
@@ -1,0 +1,39 @@
+{
+    "id": "w8m40J8TlaVF5GBLxAgc",
+    "name": "Adding overrideStyleParams class name",
+    "dod": "In this unit you will add overrideStyleParams as a class name of the component's root.",
+    "description": "We should remember to pass the `overrideStyleParams` selector to the `st` function of the root element inside our component, in order to actually apply that selector as part of `classNames`.",
+    "summary": "",
+    "hunksOrder": [
+        "src/components/FloatingDropdown/FloatingDropdown.tsx_0"
+    ],
+    "tests": [],
+    "hints": [],
+    "play_mode": "walkthrough",
+    "swimmPatch": {
+        "src/components/FloatingDropdown/FloatingDropdown.tsx": {
+            "diffType": "MODIFIED",
+            "fileDiffHeader": "diff --git a/src/components/FloatingDropdown/FloatingDropdown.tsx b/src/components/FloatingDropdown/FloatingDropdown.tsx\nindex 3c0a16d..3c0a16d 100644\n--- a/src/components/FloatingDropdown/FloatingDropdown.tsx\n+++ b/src/components/FloatingDropdown/FloatingDropdown.tsx",
+            "hunks": [
+                {
+                    "swimmHunkMetadata": {
+                        "hunkComments": []
+                    },
+                    "hunkDiffLines": [
+                        "@@ -166,7 +166,6 @@",
+                        "             className={st(",
+                        "               classes.root,",
+                        "               { mobile },",
+                        "-              classes.overrideStyleParams,",
+                        "               this.props.className,",
+                        "             )}",
+                        "           >"
+                    ]
+                }
+            ]
+        }
+    },
+    "app_version": "0.2.8",
+    "file_version": "1.0.4",
+    "last_commit_sha_for_swimm_patch": "23697c37ad83d6f1474072c859d9d3bb0644d1ce"
+}


### PR DESCRIPTION
This PR adds a complete guide explaining, using `FloatingDropdown`, how to support `overrideStyleParams` based on https://github.com/wix/wix-ui-tpa/pull/503.

These are the units:
![image](https://user-images.githubusercontent.com/7141972/101282302-12582a00-37dd-11eb-97b8-63d445dcb44c.png)