### PR TITLE
feat(RadioButton, Checkbox) - add disabled mode state for theme box and some bug fixes.

### DIFF
--- a/src/components/Checkbox/Checkbox.st.css
+++ b/src/components/Checkbox/Checkbox.st.css
@@ -89,21 +89,6 @@
     padding: 0 16px;
 }
 
-.root:box::after {
-    content: '';
-    width: 100%;
-    height: 100%;
-    position: absolute;
-    top: -1px;
-    left: -1px;
-    display: block;
-    background-color: applyOpacity(value(CurrentIconColor), 0.1);
-    border: 1px solid color(value(CurrentIconColor));
-    pointer-events: none;
-    opacity: 0;
-    transition: opacity 0.2s linear;
-}
-
 .root:box::childContainer {
     padding: 16px 0;
 }
@@ -160,8 +145,23 @@
     border-color: applyOpacity(value(CurrentBoxBorderColor), 1);
 }
 
+.root:box:checked {
+    background-color: applyOpacity(value(CurrentIconColor), 0.1);
+    border: 1px solid color(value(CurrentIconColor));
+}
+
+.root:box.disabled, .root:box:disabled {
+    /*border-color: blue;*/
+    /*background-color: lightgray;*/
+}
+
 .root:box.disabled:hover:not(:checked), .root:box:disabled:focus-within:not(:checked) {
     border-color: applyOpacity(value(CurrentBoxBorderColor), 0.6);
+}
+
+.root:box.disabled:checked, .root:box:disabled:checked {
+    /*border-color: red;*/
+    /*background-color: lightpink;*/
 }
 
 .root:box:checked::after {

--- a/src/components/Checkbox/Checkbox.st.css
+++ b/src/components/Checkbox/Checkbox.st.css
@@ -13,23 +13,43 @@
     -st-named: errorColor;
 }
 
+/*Defaults*/
 :vars {
-    /*Defaults*/
     DefaultTextColor: color-5;
     DefaultBorderColor: color-5;
-    DefaultBoxBorderColor: color-5;
     DefaultIconColor: color-8;
+    DefaultBoxBorderColor: color-5;
     DefaultBoxColor: color-1;
     DisabledColor: color-3;
     Font: font("{theme: 'Body-M', size: '16px', lineHeight: '24px'}");
 }
 
+/*Overrides*/
 :vars {
-    /*Overrides*/
+    /*
+        The checkbox text color
+        @default color-5
+    */
     TextColor: --overridable;
+    /*
+        The checkbox border color. FYI, An opacity of  0.6 will be added.
+        @default color-5
+    */
     BorderColor: --overridable;
-    BoxBorderColor: --overridable;
+    /*
+        The color of the icon
+        @default color-8
+    */
     IconColor: --overridable;
+    /*
+        The box border color. FYI, This value won't be affected on disabled mode.
+        @default color-5
+    */
+    BoxBorderColor: --overridable;
+    /*
+        The box background color. FYI, This value won't be affected on disabled mode.
+        @default color-1
+    */
     BoxColor: --overridable;
 }
 

--- a/src/components/Checkbox/Checkbox.st.css
+++ b/src/components/Checkbox/Checkbox.st.css
@@ -151,8 +151,8 @@
 }
 
 .root:box.disabled, .root:box:disabled {
-    /*border-color: blue;*/
-    /*background-color: lightgray;*/
+    border-color: color(value(DisabledColor));
+    background-color: color(value(DefaultBoxColor))
 }
 
 .root:box.disabled:hover:not(:checked), .root:box:disabled:focus-within:not(:checked) {
@@ -160,8 +160,8 @@
 }
 
 .root:box.disabled:checked, .root:box:disabled:checked {
-    /*border-color: red;*/
-    /*background-color: lightpink;*/
+    border-color: color(value(DisabledColor));
+    background-color: applyOpacity(color(value(DisabledColor)), 0.1);
 }
 
 .root:box:checked::after {

--- a/src/components/Checkbox/Checkbox.visual.tsx
+++ b/src/components/Checkbox/Checkbox.visual.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { storiesOf } from '@storybook/react';
+import { snap, story, visualize } from 'storybook-snapper';
 import { VisualTestContainer } from '../../../test/visual/VisualTestContainer';
 import { Checkbox, CheckboxTheme } from './';
 
@@ -7,80 +7,43 @@ class CheckboxVisual extends React.Component<any> {
   render() {
     return (
       <VisualTestContainer>
-        <Checkbox {...this.props} onChange={() => {}} />
+        <Checkbox {...this.props} label="Amazing" onChange={() => {}} />
       </VisualTestContainer>
     );
   }
 }
 
-const tests = [
-  {
-    describe: 'basic',
-    its: [
-      {
-        it: 'default',
-        props: {
-          onChange: () => {},
-          label: 'Amazing',
-        },
-      },
-      {
-        it: 'error',
-        props: {
-          error: true,
-          onChange: () => {},
-          label: 'Amazing',
-        },
-      },
-      {
-        it: 'disabled',
-        props: {
-          disabled: true,
-          onChange: () => {},
-          label: 'Amazing',
-        },
-      },
-      {
-        it: 'checked',
-        props: {
-          checked: true,
-          onChange: () => {},
-          label: 'Amazing',
-        },
-      },
-      {
-        it: 'indeterminate',
-        props: {
-          indeterminate: true,
-          onChange: () => {},
-          label: 'Amazing',
-        },
-      },
-      {
-        it: 'box',
-        props: {
-          theme: CheckboxTheme.Box,
-          onChange: () => {},
-          label: 'Amazing',
-        },
-      },
-      {
-        it: 'suffix',
-        props: {
-          suffix: '$50,000',
-          theme: CheckboxTheme.Box,
-          onChange: () => {},
-          label: 'Amazing',
-        },
-      },
-    ],
-  },
-];
+visualize('Checkbox', () => {
+  story('default', () => {
+    Object.values(CheckboxTheme).map(theme => {
+      snap(`${theme} / default`,  <CheckboxVisual theme={theme} />);
+    });
+  });
 
-tests.forEach(({ describe, its }) => {
-  its.forEach(({ it, props }) => {
-    storiesOf(`Checkbox/${describe}`, module).add(it, () => (
-      <CheckboxVisual {...props} />
-    ));
+  story('checked', () => {
+    Object.values(CheckboxTheme).map(theme => {
+      snap(`${theme} / checked`,  <CheckboxVisual theme={theme} checked />);
+    });
+  });
+
+  story('error', () => {
+    snap(`${CheckboxTheme.Default} / error`,  <CheckboxVisual theme={CheckboxTheme.Default} error />);
+  });
+
+  story('disabled', () => {
+    Object.values(CheckboxTheme).map(theme => {
+      snap(`${theme} / disabled`,  <CheckboxVisual theme={theme} disabled />);
+      snap(`${theme} / disabled / checked`,  <CheckboxVisual theme={theme} disabled checked />);
+    });
+  });
+
+  story('indeterminate', () => {
+    Object.values(CheckboxTheme).map(theme => {
+      snap(`${theme} / indeterminate`,  <CheckboxVisual theme={theme} indeterminate />);
+    });
+  });
+
+  story('suffix', () => {
+    snap( `${CheckboxTheme.Box} / suffix`,  <CheckboxVisual theme={CheckboxTheme.Box} suffix="$50,000" />);
   });
 });

--- a/src/components/Checkbox/Checkbox.visual.tsx
+++ b/src/components/Checkbox/Checkbox.visual.tsx
@@ -16,34 +16,46 @@ class CheckboxVisual extends React.Component<any> {
 visualize('Checkbox', () => {
   story('default', () => {
     Object.values(CheckboxTheme).map(theme => {
-      snap(`${theme} / default`,  <CheckboxVisual theme={theme} />);
+      snap(`${theme} / default`, <CheckboxVisual theme={theme} />);
     });
   });
 
   story('checked', () => {
     Object.values(CheckboxTheme).map(theme => {
-      snap(`${theme} / checked`,  <CheckboxVisual theme={theme} checked />);
+      snap(`${theme} / checked`, <CheckboxVisual theme={theme} checked />);
     });
   });
 
   story('error', () => {
-    snap(`${CheckboxTheme.Default} / error`,  <CheckboxVisual theme={CheckboxTheme.Default} error />);
+    snap(
+      `${CheckboxTheme.Default} / error`,
+      <CheckboxVisual theme={CheckboxTheme.Default} error />,
+    );
   });
 
   story('disabled', () => {
     Object.values(CheckboxTheme).map(theme => {
-      snap(`${theme} / disabled`,  <CheckboxVisual theme={theme} disabled />);
-      snap(`${theme} / disabled / checked`,  <CheckboxVisual theme={theme} disabled checked />);
+      snap(`${theme} / disabled`, <CheckboxVisual theme={theme} disabled />);
+      snap(
+        `${theme} / disabled / checked`,
+        <CheckboxVisual theme={theme} disabled checked />,
+      );
     });
   });
 
   story('indeterminate', () => {
     Object.values(CheckboxTheme).map(theme => {
-      snap(`${theme} / indeterminate`,  <CheckboxVisual theme={theme} indeterminate />);
+      snap(
+        `${theme} / indeterminate`,
+        <CheckboxVisual theme={theme} indeterminate />,
+      );
     });
   });
 
   story('suffix', () => {
-    snap( `${CheckboxTheme.Box} / suffix`,  <CheckboxVisual theme={CheckboxTheme.Box} suffix="$50,000" />);
+    snap(
+      `${CheckboxTheme.Box} / suffix`,
+      <CheckboxVisual theme={CheckboxTheme.Box} suffix="$50,000" />,
+    );
   });
 });

--- a/src/components/Checkbox/docs/examples.ts
+++ b/src/components/Checkbox/docs/examples.ts
@@ -28,6 +28,10 @@ export const exampleWithCheckedBox = `
 <Checkbox theme="box" checked onChange={val => console.log(val)} label="A checkbox!" />
 `;
 
+export const exampleWithDisabledBox = `
+<Checkbox theme="box" disabled onChange={val => console.log(val)} label="I'm a disabled, checked box 😶" />
+`;
+
 export const exampleWithDisabledCheckedBox = `
 <Checkbox theme="box" checked disabled onChange={val => console.log(val)} label="I'm a disabled, checked box 😶" />
 `;

--- a/src/components/Checkbox/docs/index.story.tsx
+++ b/src/components/Checkbox/docs/index.story.tsx
@@ -85,7 +85,7 @@ export default {
         title: 'Usage',
         sections: [
           description(
-              '`RadioButton` is a component allowing to render a single radio button',
+            'Checkbox allows the user to select one or more items from a set.',
           ),
 
           importExample({

--- a/src/components/Checkbox/docs/index.story.tsx
+++ b/src/components/Checkbox/docs/index.story.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Checkbox, CheckboxTheme } from '../';
 import * as examples from './examples';
 import {
+  description,
   header,
   api,
   divider,
@@ -14,7 +15,10 @@ import {
   title,
 } from 'wix-storybook-utils/Sections';
 import { allComponents } from '../../../../stories/utils/allComponents';
-import { settingsPanel } from '../../../../stories/utils/SettingsPanel';
+import {
+  autoSettingsPanel,
+  settingsPanel,
+} from '../../../../stories/utils/SettingsPanel';
 import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import * as ExtendedRawSource from '!raw-loader!./CheckboxExtendedExample.tsx';
 import * as ExtendedCSSRawSource from '!raw-loader!./CheckboxExtendedExample.st.css';
@@ -43,6 +47,10 @@ const codeExamples = [
   {
     title: 'With checked box',
     source: examples.exampleWithCheckedBox,
+  },
+  {
+    title: 'With disabled box',
+    source: examples.exampleWithDisabledBox,
   },
   {
     title: 'With disabled, checked box',
@@ -76,6 +84,10 @@ export default {
       tab({
         title: 'Usage',
         sections: [
+          description(
+              '`RadioButton` is a component allowing to render a single radio button',
+          ),
+
           importExample({
             source: examples.importExample,
           }),
@@ -89,10 +101,10 @@ export default {
       }),
 
       ...[
+        { title: 'Playground', sections: [playground(), autoSettingsPanel()] },
         { title: 'API', sections: [api()] },
         { title: 'Style API', sections: [settingsApi()] },
         { title: 'TestKit', sections: [testkit()] },
-        { title: 'Playground', sections: [playground()] },
         {
           title: 'Settings Panel',
           sections: [

--- a/src/components/RadioButton/RadioButton.st.css
+++ b/src/components/RadioButton/RadioButton.st.css
@@ -24,9 +24,25 @@
 
 /*Overrides*/
 :vars {
+    /*
+        The radio button text color
+        @default color-5
+    */
     TextColor: --overridable;
+    /*
+        The border color. FYI, An opacity of 0.6 will be added.
+        @default color-5
+    */
     BorderColor: --overridable;
+    /*
+        The color of the icon. This color would be used as the box's border color as well.
+        @default color-8
+    */
     IconColor:  --overridable;
+    /*
+        The box's background color. FYI, This value won't be affected on disabled mode.
+        @default color-1
+    */
     BackgroundColor:--overridable;
 }
 

--- a/src/components/RadioButton/RadioButton.st.css
+++ b/src/components/RadioButton/RadioButton.st.css
@@ -167,6 +167,13 @@
 .root:box:disabled .wrapper {
     filter: none;
     opacity: 1;
+    /*border-color: blue;*/
+    /*background-color: lightgray;*/
+}
+
+.root:box:disabled:checked .wrapper {
+    /*border-color: red;*/
+    /*background-color: lightpink;*/
 }
 
 /* Create the indicator (the dot/circle - hidden when not checked) */

--- a/src/components/RadioButton/RadioButton.st.css
+++ b/src/components/RadioButton/RadioButton.st.css
@@ -179,8 +179,10 @@
 }
 
 .root:box:disabled .wrapper {
+    /* overriding the styling from wix-ui-core */
     filter: none;
     opacity: 1;
+    /*******/
     border-color: color(value(DisabledColor));
     background-color: color(value(DefaultBackgroundColor));
 }

--- a/src/components/RadioButton/RadioButton.st.css
+++ b/src/components/RadioButton/RadioButton.st.css
@@ -35,8 +35,6 @@
     CurrentIconColor: color(fallback(value(IconColor), value(DefaultIconColor)));
     CurrentTextColor: color(fallback(value(TextColor), value(DefaultTextColor)));
     CurrentBackgroundColor: color(fallback(value(BackgroundColor), value(DefaultBackgroundColor)));
-    /*CurrentBoxColor*/
-    /*CurrentBoxBorderColor*/
     LabelTextFont: "{theme: 'Body-M', size: '16px', lineHeight: '1.5em'}";
 }
 
@@ -167,13 +165,13 @@
 .root:box:disabled .wrapper {
     filter: none;
     opacity: 1;
-    /*border-color: blue;*/
-    /*background-color: lightgray;*/
+    border-color: color(value(DisabledColor));
+    background-color: color(value(DefaultBackgroundColor));
 }
 
 .root:box:disabled:checked .wrapper {
-    /*border-color: red;*/
-    /*background-color: lightpink;*/
+    border-color: color(value(DisabledColor));
+    background-color: applyOpacity(color(value(DisabledColor)), 0.1);
 }
 
 /* Create the indicator (the dot/circle - hidden when not checked) */

--- a/src/components/RadioButton/RadioButton.st.css
+++ b/src/components/RadioButton/RadioButton.st.css
@@ -162,6 +162,10 @@
     box-sizing: border-box;
 }
 
+.root:box:disabled .wrapper {
+    filter: none;
+    opacity: 1;
+}
 
 /* Create the indicator (the dot/circle - hidden when not checked) */
 

--- a/src/components/RadioButton/RadioButton.st.css
+++ b/src/components/RadioButton/RadioButton.st.css
@@ -35,6 +35,8 @@
     CurrentIconColor: color(fallback(value(IconColor), value(DefaultIconColor)));
     CurrentTextColor: color(fallback(value(TextColor), value(DefaultTextColor)));
     CurrentBackgroundColor: color(fallback(value(BackgroundColor), value(DefaultBackgroundColor)));
+    /*CurrentBoxColor*/
+    /*CurrentBoxBorderColor*/
     LabelTextFont: "{theme: 'Body-M', size: '16px', lineHeight: '1.5em'}";
 }
 

--- a/src/components/RadioButton/RadioButton.visual.tsx
+++ b/src/components/RadioButton/RadioButton.visual.tsx
@@ -11,24 +11,30 @@ const VisualRadioButton = (
 visualize('RadioButton', () => {
   story('default', () => {
     Object.values(RadioButtonTheme).map(theme => {
-      snap(`${theme} / default`, <VisualRadioButton theme={theme}/>);
+      snap(`${theme} / default`, <VisualRadioButton theme={theme} />);
     });
   });
 
   story('checked', () => {
     Object.values(RadioButtonTheme).map(theme => {
-      snap(`${theme} / checked`,  <VisualRadioButton theme={theme} checked />);
+      snap(`${theme} / checked`, <VisualRadioButton theme={theme} checked />);
     });
   });
 
   story('disabled', () => {
     Object.values(RadioButtonTheme).map(theme => {
       snap(`${theme} / disabled`, <VisualRadioButton theme={theme} disabled />);
-      snap(`${theme} / disabled / checked`, <VisualRadioButton theme={theme} disabled checked />);
+      snap(
+        `${theme} / disabled / checked`,
+        <VisualRadioButton theme={theme} disabled checked />,
+      );
     });
   });
 
   story('error', () => {
-    snap(`${RadioButtonTheme.Default} / error`,  <VisualRadioButton theme={RadioButtonTheme.Default} error />);
+    snap(
+      `${RadioButtonTheme.Default} / error`,
+      <VisualRadioButton theme={RadioButtonTheme.Default} error />,
+    );
   });
 });

--- a/src/components/RadioButton/RadioButton.visual.tsx
+++ b/src/components/RadioButton/RadioButton.visual.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { visualize, story, snap } from 'storybook-snapper';
-import { RadioButton } from './';
+import { RadioButton, RadioButtonTheme } from './';
 import { RadioButtonProps } from './RadioButton';
 import { Omit } from '../../types';
 
@@ -8,10 +8,27 @@ const VisualRadioButton = (
   props: Omit<RadioButtonProps, 'label' | 'onChange' | 'value'>,
 ) => <RadioButton label="label" value="value" onChange={() => {}} {...props} />;
 
-visualize('ShareButton', () => {
-  story('render', () => {
-    snap('checked', <VisualRadioButton checked />);
-    snap('disabled', <VisualRadioButton disabled />);
-    snap('default', <VisualRadioButton />);
+visualize('RadioButton', () => {
+  story('default', () => {
+    Object.values(RadioButtonTheme).map(theme => {
+      snap(`${theme} / default`, <VisualRadioButton theme={theme}/>);
+    });
+  });
+
+  story('checked', () => {
+    Object.values(RadioButtonTheme).map(theme => {
+      snap(`${theme} / checked`,  <VisualRadioButton theme={theme} checked />);
+    });
+  });
+
+  story('disabled', () => {
+    Object.values(RadioButtonTheme).map(theme => {
+      snap(`${theme} / disabled`, <VisualRadioButton theme={theme} disabled />);
+      snap(`${theme} / disabled / checked`, <VisualRadioButton theme={theme} disabled checked />);
+    });
+  });
+
+  story('error', () => {
+    snap(`${RadioButtonTheme.Default} / error`,  <VisualRadioButton theme={RadioButtonTheme.Default} error />);
   });
 });

--- a/src/components/RadioButton/docs/examples.ts
+++ b/src/components/RadioButton/docs/examples.ts
@@ -15,7 +15,12 @@ export const disabledExample = `
 export const boxExample = `
 <RadioButton value={'Checked'}  checked theme='box' onChange={val => console.log(val)}  label="Checked" />
 `;
+
 export const boxExampleDisabled = `
+<RadioButton suffix="$" disabled theme='box' onChange={val => console.log(val)}  label="Checked" />
+`;
+
+export const boxExampleDisabledChecked = `
 <RadioButton value={'Checked'} suffix="$" disabled checked theme='box' onChange={val => console.log(val)}  label="Checked" />
 `;
 

--- a/src/components/RadioButton/docs/index.story.tsx
+++ b/src/components/RadioButton/docs/index.story.tsx
@@ -75,7 +75,10 @@ export default {
             { title: 'Disabled box', source: examples.boxExampleDisabled },
           ].map(code),
           ...[
-            { title: 'Disabled, Checked box', source: examples.boxExampleDisabledChecked },
+            {
+              title: 'Disabled, Checked box',
+              source: examples.boxExampleDisabledChecked,
+            },
           ].map(code),
           ...[{ title: 'Suffixed', source: examples.suffixExample }].map(code),
           ...[{ title: 'Error', source: examples.errorExample }].map(code),

--- a/src/components/RadioButton/docs/index.story.tsx
+++ b/src/components/RadioButton/docs/index.story.tsx
@@ -74,6 +74,9 @@ export default {
           ...[
             { title: 'Disabled box', source: examples.boxExampleDisabled },
           ].map(code),
+          ...[
+            { title: 'Disabled, Checked box', source: examples.boxExampleDisabledChecked },
+          ].map(code),
           ...[{ title: 'Suffixed', source: examples.suffixExample }].map(code),
           ...[{ title: 'Error', source: examples.errorExample }].map(code),
         ],

--- a/src/components/RadioButton/index.tsx
+++ b/src/components/RadioButton/index.tsx
@@ -1,1 +1,1 @@
-export { RadioButton, RadioButtonProps } from './RadioButton';
+export { RadioButton, RadioButtonProps, RadioButtonTheme } from './RadioButton';


### PR DESCRIPTION
This PR solves some bugs that @barboaron from the RichContentEditor team found.
In addition, I added some styles for the Box theme on disabled mode according to this spec: https://zeroheight.com/7sjjzhgo2/p/05a744-05-selections/b/285e96.

The bugs that were fixed:
1. In the checkbox component: fix the box border overlapping issue.
2. In the RadioButton component: Override the styling that comes from the wix-ui-core.