### PR TITLE
Add option for FloatingDropdown to hide placeholder from options

### DIFF
--- a/src/components/FloatingDropdown/FloatingDropdown.tsx
+++ b/src/components/FloatingDropdown/FloatingDropdown.tsx
@@ -31,6 +31,8 @@ export interface FloatingDropdownProps extends TPAComponentProps {
   options: FloatingDropdownOptionProps[];
   /** A placeholder which is being displayed when no value is selected. String. Optional. */
   placeholder?: string;
+  /** Hides placeholder from options in native version. Optional. Boolean */
+  hidePlaceholderFromOptions?: boolean;
   /** An id of initially selected item. String. Optional. */
   value?: string;
   /** Force dropdown open. Use for visual test. Optional. Boolean. */

--- a/src/components/FloatingDropdown/FloatingDropdownBase.tsx
+++ b/src/components/FloatingDropdown/FloatingDropdownBase.tsx
@@ -18,6 +18,7 @@ interface FloatingDropdownBaseProps extends TPAComponentProps {
   name?: string;
   id?: string;
   onChange?(selectedOption: FloatingDropdownOptionProps): void;
+  hidePlaceholderFromOptions?: boolean;
 }
 
 export class FloatingDropdownBase extends React.Component<
@@ -41,6 +42,7 @@ export class FloatingDropdownBase extends React.Component<
     const {
       value,
       placeholder,
+      hidePlaceholderFromOptions,
       label,
       options,
       ['aria-labelledby']: ariaLabelledBy,
@@ -78,7 +80,7 @@ export class FloatingDropdownBase extends React.Component<
             onChange={this._onSelect}
             disabled={disabled}
           >
-            {placeholder ? (
+            {placeholder && !hidePlaceholderFromOptions ? (
               <option value="" disabled>
                 {placeholder}
               </option>


### PR DESCRIPTION
In native version we always see placeholder as disabled option in the
option list, but if the dropdown is never empty and placeholder is
used to display currently selected value than the disabled option is
confusing to the user. This is solved by adding optional boolean option
`hidePlaceholderFromOptions`