### PR TITLE
Dialog: fix not wired state

### DIFF
--- a/src/components/Dialog/Dialog.st.css
+++ b/src/components/Dialog/Dialog.st.css
@@ -63,29 +63,21 @@
 }
 
 /* New style overrides capabilities */
-.skin-fixed {
-    -st-extends: root;
-}
-
-.skin-wired {
-    -st-extends: root;
-}
-
-.skin-fixed:not(:wired) .contentWrapper {
+.root:not(:wired).skin-fixed .contentWrapper {
     background-color: value(FixedBackgroundColor);
 }
 
-.skin-fixed:not(:wired) .closeIconButton {
+.root:not(:wired).skin-fixed .closeIconButton {
     -st-mixin: skin-line(
         IconColor value(FixedCloseButtonColor)
     );
 }
 
-.skin-wired:wired .contentWrapper {
+.root:wired.skin-wired .contentWrapper {
     background-color: value(WiredBackgroundColor);
 }
 
-.skin-wired:wired .closeIconButton {
+.root:wired.skin-wired .closeIconButton {
     -st-mixin: skin-line(
         IconColor value(WiredCloseButtonColor)
     );

--- a/src/components/Dialog/Dialog.st.css
+++ b/src/components/Dialog/Dialog.st.css
@@ -23,7 +23,7 @@
 }
 
 .root {
-    -st-states: mobile, rtl;
+    -st-states: mobile, rtl, wired;
 }
 
 .contentWrapper {
@@ -63,21 +63,29 @@
 }
 
 /* New style overrides capabilities */
-.skin-fixed .contentWrapper {
+.skin-fixed {
+    -st-extends: root;
+}
+
+.skin-wired {
+    -st-extends: root;
+}
+
+.skin-fixed:not(:wired) .contentWrapper {
     background-color: value(FixedBackgroundColor);
 }
 
-.skin-fixed .closeIconButton {
+.skin-fixed:not(:wired) .closeIconButton {
     -st-mixin: skin-line(
         IconColor value(FixedCloseButtonColor)
     );
 }
 
-.skin-wired .contentWrapper {
+.skin-wired:wired .contentWrapper {
     background-color: value(WiredBackgroundColor);
 }
 
-.skin-wired .closeIconButton {
+.skin-wired:wired .closeIconButton {
     -st-mixin: skin-line(
         IconColor value(WiredCloseButtonColor)
     );

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -70,7 +70,7 @@ export class Dialog extends React.Component<DialogProps> {
           <div
             className={st(
               classes.root,
-              { mobile, rtl },
+              { mobile, rtl, wired: wiredToSiteColors },
               classes[`skin-${wiredToSiteColors ? 'wired' : 'fixed'}`],
               className,
             )}


### PR DESCRIPTION
I've noticed that my previous work on the Dialog had a bug:

the `wiredToSiteColors` prop only worked when consumers didn't actively pass colors (using st-mixin).
So for instance, if you go to the Dialog settings panel, in our live storybook site, you'll see that once you select colors to override, the toggle doesn't take any effect.

This PR fixes this issue.