### PR TITLE
fix: prevent ios zoom in FloatingDropdown

### DIFF
--- a/src/components/FloatingDropdown/FloatingDropdownBase.st.css
+++ b/src/components/FloatingDropdown/FloatingDropdownBase.st.css
@@ -130,6 +130,7 @@
     width: 100%;
     height: 100%;
     color: transparent;
+    font-size: 16px;
 }
 
 .root:mobile:disabled select {


### PR DESCRIPTION
ios auto zooms if clicking on input element which has font-size smaller than 16px, this fixes this.