### PR TITLE
fix(TextArea) - Use the default backgroundColor param

### DIFF
--- a/src/components/TextArea/TextArea.st.css
+++ b/src/components/TextArea/TextArea.st.css
@@ -58,7 +58,7 @@
 
 :vars {
     borderColor: color(fallback(value(BorderColor), value(DefaultBorderColor)));
-    backgroundColor: color(fallback(value(BackgroundColor), value(BackgroundColor)));
+    backgroundColor: color(fallback(value(BackgroundColor), value(DefaultBackgroundColor)));
     textColor: color(fallback(value(TextColor), value(DefaultTextColor)));
     disabledTextColor: color(fallback(value(DisabledTextColor), value(DefaultDisabledTextColor)));
     placeholderColor: color(fallback(value(PlaceholderColor), value(DefaultPlaceholderColor)));


### PR DESCRIPTION
<!--
  Thanks for creating a pull request to `wix-ui-tpa`!

  =========================
   Before creating the PR:
  =========================
  
    - Please make sure your commits are signed,the PR cannot be merged without it.
      Read more about it here:
      https://github.com/wix/wix-style-react/blob/master/docs/contribution/CREATE_PR.md#sign-commits
      
    - If the PR changes/adds something to the UI, make sure it's aligned to the design system specs:
      https://zeroheight.com/7sjjzhgo2/p/7181b5-tpa-design-system
      
  -->

# ✨ Pull Request

### 💁 Description

Use the param of the default background color as a fallback.

<!---
  Tell us what this PR is supposed to solve, add a link to related
  issues/tasks from Zeplin/Notion/Jira/Github issue if relevant. 
  e.g 
  "Implement new component ShinyNewComponent"
-->

...

### 💭 Motivation

<!---
  Why is this solution right for the issue/task?
  If infra task - how will this make our life better?
  e.g 
  "- Will reduce bundle size by X"
  ...
  -->

...


### ☝️ TODOs <!-- optional -->

<!---
  List leftover tasks, related PR's blocking this etc...
  e.g
  "- [ ] waiting for PR merge in wix-ui-core"
  ...
  -->
...

### 👀  PR is ready for review 

<!-- mark checkbox to let reviewers know you're ready -->

- [ ] Ready for review
