### PR TITLE
Feat/multiline boxes

### DIFF
--- a/src/components/Checkbox/Checkbox.st.css
+++ b/src/components/Checkbox/Checkbox.st.css
@@ -79,7 +79,6 @@
 .root::childContainer {
     display: flex;
     flex: 1;
-    flex-wrap: wrap;
     align-items: center;
 }
 
@@ -98,7 +97,6 @@
     display: flex;
     align-items: center;
 }
-
 
 .root:box {
     display: flex;
@@ -147,13 +145,13 @@
 
 .label.suffixed {
     flex: 1;
-    white-space: nowrap;
     display: flex;
 }
 
 .label.suffixed::after {
     content: '';
     width: 5px;
+    flex: 1 0 5px;
 }
 
 .suffix {

--- a/src/components/Checkbox/Checkbox.visual.tsx
+++ b/src/components/Checkbox/Checkbox.visual.tsx
@@ -1,13 +1,17 @@
 import * as React from 'react';
 import { snap, story, visualize } from 'storybook-snapper';
 import { VisualTestContainer } from '../../../test/visual/VisualTestContainer';
-import { Checkbox, CheckboxTheme } from './';
+import { Checkbox, CheckboxTheme, CheckboxProps } from './';
 
-class CheckboxVisual extends React.Component<any> {
+class CheckboxVisual extends React.Component<Partial<CheckboxProps>> {
   render() {
     return (
       <VisualTestContainer>
-        <Checkbox {...this.props} label="Amazing" onChange={() => {}} />
+        <Checkbox
+          {...this.props}
+          label={this.props.label || 'Amazing'}
+          onChange={() => {}}
+        />
       </VisualTestContainer>
     );
   }
@@ -56,6 +60,24 @@ visualize('Checkbox', () => {
     snap(
       `${CheckboxTheme.Box} / suffix`,
       <CheckboxVisual theme={CheckboxTheme.Box} suffix="$50,000" />,
+    );
+  });
+
+  story('long', () => {
+    snap(
+      `${CheckboxTheme.Box} / long`,
+      <CheckboxVisual
+        theme={CheckboxTheme.Box}
+        label="It is a period of civil war. Rebel spaceships, striking from a hidden base, have won their first victory against the evil Galactic Empire. During the battle, Rebel spies managed to steal secret plans to the Empire's ultimate weapon, the DEATH STAR, an armored space station with enough power to destroy an entire planet."
+      />,
+    );
+    snap(
+      `${CheckboxTheme.Box} / long / suffix`,
+      <CheckboxVisual
+        theme={CheckboxTheme.Box}
+        suffix="$50,000"
+        label="It is a period of civil war. Rebel spaceships, striking from a hidden base, have won their first victory against the evil Galactic Empire. During the battle, Rebel spies managed to steal secret plans to the Empire's ultimate weapon, the DEATH STAR, an armored space station with enough power to destroy an entire planet."
+      />,
     );
   });
 });

--- a/src/components/RadioButton/RadioButton.st.css
+++ b/src/components/RadioButton/RadioButton.st.css
@@ -59,8 +59,10 @@
     align-items: center;
     justify-content: space-between;
 }
+
 .wrapper{
     display: flex;
+    align-items: center;
     -st-extends: RadioButton;
     cursor: pointer;
 }
@@ -70,8 +72,6 @@
 }
 
 .radioIcon {
-    position: absolute;
-    top:1px;
     background-color: transparent;
     height: 16px;
     border-radius: 50%;
@@ -106,13 +106,13 @@
 
 .label.suffixed {
     flex: 1;
-    white-space: nowrap;
     display: flex;
 }
 
 .label.suffixed::after {
     content: '';
     width: 5px;
+    flex: 1 0 5px;
 }
 
 .suffix {
@@ -159,18 +159,15 @@
 
 .wrapper::icon {
     display: flex;
-    position: relative;
-    margin-bottom: 1px;
-    top:4px;
     -webkit-user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;
     user-select: none;
 }
 
-.wrapper::icon::before {
+.wrapper::icon::after {
     content: '';
-    width: 28px;
+    width: 12px;
 }
 
 .root:box .wrapper{

--- a/src/components/RadioButton/RadioButton.visual.tsx
+++ b/src/components/RadioButton/RadioButton.visual.tsx
@@ -2,11 +2,15 @@ import * as React from 'react';
 import { visualize, story, snap } from 'storybook-snapper';
 import { RadioButton, RadioButtonTheme } from './';
 import { RadioButtonProps } from './RadioButton';
-import { Omit } from '../../types';
 
-const VisualRadioButton = (
-  props: Omit<RadioButtonProps, 'label' | 'onChange' | 'value'>,
-) => <RadioButton label="label" value="value" onChange={() => {}} {...props} />;
+const VisualRadioButton = (props: Partial<RadioButtonProps>) => (
+  <RadioButton
+    label={props.label || 'label'}
+    value="value"
+    onChange={() => {}}
+    {...props}
+  />
+);
 
 visualize('RadioButton', () => {
   story('default', () => {
@@ -35,6 +39,24 @@ visualize('RadioButton', () => {
     snap(
       `${RadioButtonTheme.Default} / error`,
       <VisualRadioButton theme={RadioButtonTheme.Default} error />,
+    );
+  });
+
+  story('long', () => {
+    snap(
+      `${RadioButtonTheme.Box} / long`,
+      <VisualRadioButton
+        theme={RadioButtonTheme.Box}
+        label="It is a period of civil war. Rebel spaceships, striking from a hidden base, have won their first victory against the evil Galactic Empire. During the battle, Rebel spies managed to steal secret plans to the Empire's ultimate weapon, the DEATH STAR, an armored space station with enough power to destroy an entire planet."
+      />,
+    );
+    snap(
+      `${RadioButtonTheme.Box} / long / suffix`,
+      <VisualRadioButton
+        theme={RadioButtonTheme.Box}
+        suffix="$50,000"
+        label="It is a period of civil war. Rebel spaceships, striking from a hidden base, have won their first victory against the evil Galactic Empire. During the battle, Rebel spies managed to steal secret plans to the Empire's ultimate weapon, the DEATH STAR, an armored space station with enough power to destroy an entire planet."
+      />,
     );
   });
 });


### PR DESCRIPTION
Before this change, when there was too much text in a box-themed checkbox or radiobutton it would overflow the container. Now, it looks like this -

<img width="1183" alt="Screen Shot 2020-12-21 at 18 42 05" src="https://user-images.githubusercontent.com/67232912/102800216-3c544380-43bc-11eb-85c0-6e326273c618.png">
