### PR TITLE
infra - fail storybook build for incorrect stylable usage

### DIFF
--- a/src/components/Badge/Badge.visual.st.css
+++ b/src/components/Badge/Badge.visual.st.css
@@ -6,8 +6,8 @@
 
 .palette {
   -st-mixin: Badge(
-    BadgeBgColor "color(color-11)",
-    BadgeTextColor "color(color-15)",
+    BadgeBgColor '"color(color-11)"',
+    BadgeTextColor '"color(color-15)"',
   );
 }
 
@@ -20,8 +20,8 @@
 
 .paletteStyleParams {
   -st-mixin: overrideStyleParams(
-    BadgeBgColor "color(color-11)",
-    BadgeTextColor "color(color-15)",
+    BadgeBgColor '"color(color-11)"',
+    BadgeTextColor '"color(color-15)"',
   );
 }
 .staticColorsSiteParams {

--- a/src/components/CounterBadge/CounterBadge.visual.st.css
+++ b/src/components/CounterBadge/CounterBadge.visual.st.css
@@ -5,8 +5,8 @@
 
 .paletteStyleParams {
   -st-mixin: overrideStyleParams(
-    CounterBadgeBgColor "color(color-11)",
-    CounterBadgeTextColor "color(color-8)",
+    CounterBadgeBgColor '"color(color-11)"',
+    CounterBadgeTextColor '"color(color-8)"',
   );
 }
 .staticStyleParams {

--- a/webpack.config.storybook.js
+++ b/webpack.config.storybook.js
@@ -31,6 +31,7 @@ function reconfigureStylable(config) {
         return stylableResult;
       },
     },
+    diagnosticsMode: 'strict', //This ensures the storybook build will fail in case incorrect usage of stylable rules
   });
 
   //remove previous stylable config and attach new one


### PR DESCRIPTION
Currently, consumers will see this warning once they start using the DatePicker component.
The reason is for incorrect style extending.
![image](https://user-images.githubusercontent.com/6093192/103158286-b0c82180-47c4-11eb-8c49-06a60831fdac.png)

We will need to fix it anyway, but this PR makes sure the storybook build will fail (and not just throw warnings)

@sivanharel - please fix the style extending before merging