### PR TITLE
Image - make `src` to support absolute and relative

### DIFF
--- a/src/components/Image/Image.spec.tsx
+++ b/src/components/Image/Image.spec.tsx
@@ -10,61 +10,30 @@ import { imageDriverFactory } from './Image.driver';
 
 describe('Image', () => {
   const createDriver = createUniDriverFactory(imageDriverFactory);
-  const sampleUrl =
-    'https://m.media-amazon.com/images/M/MV5BZGMwOGIwZjUtOWQ1OS00YWRjLWJmZGMtN2Y1OWQ3ZDYwYTM3XkEyXkFqcGdeQXVyNzU1NzE3NTg@._V1_.jpg';
+
+  const sampleSources = {
+    absolute:
+      'https://m.media-amazon.com/images/M/MV5BZGMwOGIwZjUtOWQ1OS00YWRjLWJmZGMtN2Y1OWQ3ZDYwYTM3XkEyXkFqcGdeQXVyNzU1NzE3NTg@._V1_.jpg',
+    relative: 'c5f754_dd75514d14fa4057b4f4a6cc8ce7add3~mv2.jpg',
+  };
   const sampleAlt = 'Garfield smiles and puts his hand over chest';
 
   it('should render', async () => {
-    const driver = createDriver(<Image src={sampleUrl} />);
+    const driver = createDriver(<Image src={sampleSources.absolute} />);
     expect(await driver.exists()).toBe(true);
   });
 
-  describe('regular image', () => {
+  describe.each(Object.keys(sampleSources))('%s', (sourceType) => {
+    const src = sampleSources[sourceType];
+
     it('should return `src`', async () => {
-      const expectedSrc = sampleUrl;
-      const driver = createDriver(<Image src={expectedSrc} />);
-      expect(await driver.getSrc()).toBe(expectedSrc);
+      const driver = createDriver(<Image src={src} />);
+      expect(await driver.getSrc()).toBe(src);
     });
 
     it('should return `alt`', async () => {
-      const expectedAlt = sampleAlt;
-      const driver = createDriver(<Image src={sampleUrl} alt={expectedAlt} />);
-      expect(await driver.getAlt()).toBe(expectedAlt);
-    });
-  });
-
-  describe('media image', () => {
-    const uri = 'c5f754_dd75514d14fa4057b4f4a6cc8ce7add3~mv2.jpg';
-    const width = 300;
-    const height = 250;
-
-    it('should return `src`', async () => {
-      const expectedSrc = `https://static.wixstatic.com/media/${uri}/v1/fill/w_${width},h_${height},al_c,q_80/${uri}`;
-      const driver = createDriver(
-        <Image
-          mediaItem={{
-            uri,
-            width,
-            height,
-          }}
-        />,
-      );
-      expect(await driver.getSrc()).toBe(expectedSrc);
-    });
-
-    it('should return `alt`', async () => {
-      const expectedAlt = sampleAlt;
-      const driver = createDriver(
-        <Image
-          mediaItem={{
-            uri,
-            width,
-            height,
-          }}
-          alt={expectedAlt}
-        />,
-      );
-      expect(await driver.getAlt()).toBe(expectedAlt);
+      const driver = createDriver(<Image src={src} alt={sampleAlt} />);
+      expect(await driver.getAlt()).toBe(sampleAlt);
     });
   });
 
@@ -72,7 +41,7 @@ describe('Image', () => {
     it('should exist', async () => {
       expect(
         await isUniTestkitExists(
-          <Image src={sampleUrl} />,
+          <Image src={sampleSources.absolute} />,
           imageTestkitFactory,
           {
             dataHookPropName: 'data-hook',
@@ -86,7 +55,7 @@ describe('Image', () => {
     it('should exist', async () => {
       expect(
         await isUniEnzymeTestkitExists(
-          <Image src={sampleUrl} />,
+          <Image src={sampleSources.absolute} />,
           enzymeImageTestkitFactory,
           mount,
           {

--- a/src/components/Image/Image.spec.tsx
+++ b/src/components/Image/Image.spec.tsx
@@ -20,19 +20,49 @@ describe('Image', () => {
 
   it('should render', async () => {
     const driver = createDriver(<Image src={sampleSources.absolute} />);
+
     expect(await driver.exists()).toBe(true);
+  });
+
+  describe('absolute', () => {
+    const src = sampleSources.absolute;
+
+    it('should return `src` as is', async () => {
+      const driver = createDriver(<Image src={src} />);
+
+      expect(await driver.getSrc()).toBe(src);
+    });
+
+    it('should return `src` as is even when providing an unsecured URL', async () => {
+      const unsecuredSrc = sampleSources.absolute.replace(
+        'https://',
+        'http://',
+      );
+      const driver = createDriver(<Image src={unsecuredSrc} />);
+
+      expect(await driver.getSrc()).toBe(unsecuredSrc);
+    });
+  });
+
+  describe('relative', () => {
+    const src = sampleSources.relative;
+
+    it('should return `src` as full media item URL containing the provided URI', async () => {
+      const driver = createDriver(<Image src={src} />);
+
+      const mediaItemUrl = await driver.getSrc();
+
+      expect(mediaItemUrl.startsWith('http')).toBe(true);
+      expect(mediaItemUrl.endsWith(src)).toBe(true);
+    });
   });
 
   describe.each(Object.keys(sampleSources))('%s', (sourceType) => {
     const src = sampleSources[sourceType];
 
-    it('should return `src`', async () => {
-      const driver = createDriver(<Image src={src} />);
-      expect(await driver.getSrc()).toBe(src);
-    });
-
     it('should return `alt`', async () => {
       const driver = createDriver(<Image src={src} alt={sampleAlt} />);
+
       expect(await driver.getAlt()).toBe(sampleAlt);
     });
   });

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -1,9 +1,6 @@
 import * as React from 'react';
 import { Image as CoreImage } from 'wix-ui-core/image';
-import {
-  MediaImage,
-  MediaPlatformItem as MediaItemProps,
-} from 'wix-ui-core/media-image';
+import { MediaImage, MediaImageScaling } from 'wix-ui-core/media-image';
 import { TPAComponentProps } from '../../types';
 import { classes, st } from './Image.st.css';
 
@@ -22,7 +19,7 @@ export interface ImageProps extends TPAComponentProps {
   onError?: React.EventHandler<React.SyntheticEvent>;
 }
 
-/** Image is a component to literally display an image - whether a regular with full path or an item from the media manager */
+/** Image is a component to literally display an image - whether an absolute with full URL or a media platform item with relative URI */
 export class Image extends React.Component<ImageProps> {
   static displayName = 'Image';
 
@@ -46,8 +43,11 @@ export class Image extends React.Component<ImageProps> {
         ) : (
           <MediaImage
             {...imageProps}
-            {...dimensions}
-            mediaPlatformItem={{ uri: src, ...dimensions }}
+            mediaPlatformItem={{
+              uri: src,
+              ...dimensions,
+            }}
+            scale={MediaImageScaling.FIT}
           />
         )}
       </div>

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -47,7 +47,6 @@ export class Image extends React.Component<ImageProps> {
               uri: src,
               ...dimensions,
             }}
-            scale={MediaImageScaling.FIT}
           />
         )}
       </div>

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -8,7 +8,7 @@ import { TPAComponentProps } from '../../types';
 import { classes, st } from './Image.st.css';
 
 export interface ImageProps extends TPAComponentProps {
-  /** The full URL of the source */
+  /** The source could be any absolute full URL or a relative URI of a media platform item */
   src?: string;
   /** The intrinsic width of the image in pixels */
   width?: number;
@@ -20,8 +20,6 @@ export interface ImageProps extends TPAComponentProps {
   onLoad?: React.EventHandler<React.SyntheticEvent>;
   /** A callback to be called if error occurs while loading */
   onError?: React.EventHandler<React.SyntheticEvent>;
-  /** Exposing the MediaPlatformItem API as specified in https://wix-wix-ui-core.surge.sh/?activeTab=Usage&path=%2Fstory%2Fcomponents--media-image */
-  mediaItem?: MediaItemProps;
 }
 
 /** Image is a component to literally display an image - whether a regular with full path or an item from the media manager */
@@ -29,32 +27,27 @@ export class Image extends React.Component<ImageProps> {
   static displayName = 'Image';
 
   render() {
-    const {
-      className,
-      src,
-      width,
-      height,
-      mediaItem,
-      ...imageProps
-    } = this.props;
+    const { className, src, width, height, ...imageProps } = this.props;
     const dimensions = { width, height };
+
+    const isAbsoluteUrl = src.match('^https?://');
 
     return (
       <div
         className={st(classes.root, className)}
         data-hook={this.props['data-hook']}
       >
-        {mediaItem ? (
-          <MediaImage
-            {...imageProps}
-            {...dimensions}
-            mediaPlatformItem={mediaItem}
-          />
-        ) : (
+        {isAbsoluteUrl ? (
           <CoreImage
             {...imageProps}
             nativeProps={{ ...dimensions }}
             src={src}
+          />
+        ) : (
+          <MediaImage
+            {...imageProps}
+            {...dimensions}
+            mediaPlatformItem={{ uri: src, ...dimensions }}
           />
         )}
       </div>

--- a/src/components/Image/Image.visual.tsx
+++ b/src/components/Image/Image.visual.tsx
@@ -2,8 +2,19 @@ import * as React from 'react';
 import { snap, story, visualize } from 'storybook-snapper';
 import { Image, ImageProps } from './';
 
-const sampleUrl =
-  'https://m.media-amazon.com/images/M/MV5BZGMwOGIwZjUtOWQ1OS00YWRjLWJmZGMtN2Y1OWQ3ZDYwYTM3XkEyXkFqcGdeQXVyNzU1NzE3NTg@._V1_.jpg';
+const stories: { name: string; src: string; invalidSrc: string }[] = [
+  {
+    name: 'Absolute URL',
+    src:
+      'https://m.media-amazon.com/images/M/MV5BZGMwOGIwZjUtOWQ1OS00YWRjLWJmZGMtN2Y1OWQ3ZDYwYTM3XkEyXkFqcGdeQXVyNzU1NzE3NTg@._V1_.jpg',
+    invalidSrc: 'https://invalid.something/resource.jpg',
+  },
+  {
+    name: 'Relative URI',
+    src: 'c5f754_dd75514d14fa4057b4f4a6cc8ce7add3~mv2.jpg',
+    invalidSrc: 'invalid-resource.jpg',
+  },
+];
 
 type ImageWrapperProps = ImageProps & { onDone(): void };
 
@@ -28,27 +39,15 @@ class ImageWrapper extends React.Component<ImageWrapperProps> {
 }
 
 visualize('Image', () => {
-  story('render', () => {
-    snap('default', done => <Image src={sampleUrl} onLoad={done} />);
-    snap('with width & height', done => (
-      <Image src={sampleUrl} width={200} height={200} onLoad={done} />
-    ));
-    snap(
-      'with alt',
-      <Image alt="Garfield smiles and puts his hand over chest" />,
-    );
-    snap('with mediaItem', done => (
-      <Image
-        mediaItem={{
-          uri: 'c5f754_dd75514d14fa4057b4f4a6cc8ce7add3~mv2.jpg',
-          width: 400,
-          height: 400,
-        }}
-        onLoad={done}
-      />
-    ));
-    snap('with onError', done => (
-      <ImageWrapper src="invalid-resource" onDone={done} />
-    ));
+  stories.forEach(({ name, src, invalidSrc }) => {
+    story(name, () => {
+      snap('default', (done) => <Image src={src} onLoad={done} />);
+      snap('with width & height', (done) => (
+        <Image src={src} width={200} height={200} onLoad={done} />
+      ));
+      snap('with onError', (done) => (
+        <ImageWrapper src={invalidSrc} onDone={done} />
+      ));
+    });
   });
 });

--- a/src/components/Image/docs/examples.ts
+++ b/src/components/Image/docs/examples.ts
@@ -1,6 +1,6 @@
 export const importExample = `import { Image } from 'wix-ui-tpa/Image';`;
 
-export const regularImageExample = `
+export const absoluteUrlExample = `
 <Image
   src="https://m.media-amazon.com/images/M/MV5BZGMwOGIwZjUtOWQ1OS00YWRjLWJmZGMtN2Y1OWQ3ZDYwYTM3XkEyXkFqcGdeQXVyNzU1NzE3NTg@._V1_.jpg"
   width="300"
@@ -9,11 +9,9 @@ export const regularImageExample = `
 />
 `;
 
-export const mediaImageExample = `
+export const relativeUriExample = `
 <Image
-  mediaItem={{
-    uri: 'c5f754_dd75514d14fa4057b4f4a6cc8ce7add3~mv2.jpg',
-  }}
+  src="c5f754_dd75514d14fa4057b4f4a6cc8ce7add3~mv2.jpg"
   width="300"
   height="250"
   alt="Garfield smiles and puts his hand over chest"

--- a/src/components/Image/docs/index.story.tsx
+++ b/src/components/Image/docs/index.story.tsx
@@ -16,8 +16,20 @@ import { settingsApi } from '../../../../stories/utils/SettingsApi';
 import * as examples from './examples';
 import { StoryCategory } from '../../../../stories/storyHierarchy';
 
-const code = config =>
+const code = (config) =>
   baseCode({ components: allComponents, compact: true, ...config });
+
+const sampleSources = [
+  {
+    label: 'General Absolute URL',
+    value:
+      'https://m.media-amazon.com/images/M/MV5BZGMwOGIwZjUtOWQ1OS00YWRjLWJmZGMtN2Y1OWQ3ZDYwYTM3XkEyXkFqcGdeQXVyNzU1NzE3NTg@._V1_.jpg',
+  },
+  {
+    label: 'Relative URI of a Media Item',
+    value: 'c5f754_91bd6af05038434a894097cd967c721a~mv2.jpg',
+  },
+];
 
 export default {
   category: StoryCategory.COMPONENTS,
@@ -26,25 +38,13 @@ export default {
   componentPath: '../Image.tsx',
   componentProps: () => ({
     'data-hook': 'storybook-Image',
-    src:
-      'https://m.media-amazon.com/images/M/MV5BZGMwOGIwZjUtOWQ1OS00YWRjLWJmZGMtN2Y1OWQ3ZDYwYTM3XkEyXkFqcGdeQXVyNzU1NzE3NTg@._V1_.jpg',
+    src: sampleSources[0].value,
     width: 300,
     height: 250,
     alt: 'Garfield smiles and puts his hand over chest',
   }),
   exampleProps: {
-    mediaItem: [
-      {
-        label: 'None',
-        value: null,
-      },
-      {
-        label: 'An image from media manager',
-        value: {
-          uri: 'c5f754_91bd6af05038434a894097cd967c721a~mv2.jpg',
-        },
-      },
-    ],
+    src: sampleSources,
   },
   dataHook: 'storybook-Image',
   sections: [
@@ -63,16 +63,16 @@ export default {
 
           ...[
             {
-              title: 'Regular Image',
+              title: 'General Absolute URL',
               description:
-                'This example demonstrates the usage of an external image with a full URL.',
-              source: examples.regularImageExample,
+                'This example demonstrates the usage of an image with an absolute full URL.',
+              source: examples.absoluteUrlExample,
             },
             {
-              title: 'Media Image',
+              title: 'Relative URI of a Media Item',
               description:
-                'This example demonstrates the usage of an item from the media manager.',
-              source: examples.mediaImageExample,
+                'This example demonstrates the usage of a media platform item with a relative URI.',
+              source: examples.relativeUriExample,
             },
           ].map(code),
         ],

--- a/src/components/Image/docs/index.story.tsx
+++ b/src/components/Image/docs/index.story.tsx
@@ -32,7 +32,7 @@ const sampleSources = [
 ];
 
 export default {
-  category: StoryCategory.COMPONENTS,
+  category: StoryCategory.WIP,
   storyName: 'Image',
   component: Image,
   componentPath: '../Image.tsx',


### PR DESCRIPTION
This PR removes `mediaItem` prop and makes `src` to support both absolute and relative sources.