### PR TITLE
Radio Button - adding optional aria-label prop

### DIFF
--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -35,6 +35,7 @@ export interface RadioButtonProps {
   withFocusRing?: boolean;
   children?: React.ReactNode;
   onChange?: CoreRadioButtonProps['onChange'];
+  'aria-label'?: string;
   'data-hook'?: string;
 }
 
@@ -141,11 +142,16 @@ export class RadioButton extends React.Component<
           onChange={onChange}
           checkedIcon={radioBtnIcon(focusedIcon, !!children)}
           uncheckedIcon={radioBtnIcon(focusedIcon, !!children)}
-          aria-label={label}
+          aria-label={this._getAriaLabel()}
           className={classnames(classes.wrapper)}
         />
       </div>
     );
+  }
+
+  _getAriaLabel = () => {
+    const {label} = this.props;
+    return this.props['aria-label'] ? this.props['aria-label'] : label;
   }
 
   _getContent = (suffix: string, label: string, children: React.ReactNode) => {


### PR DESCRIPTION
At [#547](https://github.com/wix/wix-ui-tpa/pull/547) the ability to use a children prop instead of label prop was added, and there is intention to deprecate the label prop in the future.

Today we use the value of label prop also for aria-label. I've exposed aria-label as an optional prop so it'd be possible to use the children prop and update 'aria-label' and not to be broken in the future when 'label' would be deprecated.