### PR TITLE
feat(wix-ui-tpa): radio-button don't show focus ring on mouse click

### DIFF
--- a/src/components/RadioButton/RadioButton.e2e.ts
+++ b/src/components/RadioButton/RadioButton.e2e.ts
@@ -24,7 +24,7 @@ describe('RadioButton', () => {
     driver = radioButtonTestkitFactory({ dataHook: boxThemeDataHook });
     await waitForVisibilityOf(
       await driver.element(),
-      'Cannot find radioButton'
+      'Cannot find radioButton',
     );
     await driver.clickInput();
     await browser.actions().sendKeys(Key.ARROW_DOWN, Key.ARROW_UP);
@@ -35,7 +35,7 @@ describe('RadioButton', () => {
     driver = radioButtonTestkitFactory({ dataHook: defaultThemeDataHook });
     await waitForVisibilityOf(
       await driver.element(),
-      'Cannot find radioButton'
+      'Cannot find radioButton',
     );
     await driver.clickInput();
     await browser.actions().sendKeys(Key.ARROW_DOWN, Key.ARROW_UP);

--- a/src/components/RadioButton/RadioButton.e2e.ts
+++ b/src/components/RadioButton/RadioButton.e2e.ts
@@ -1,5 +1,5 @@
 import * as eyes from 'eyes.it';
-import { browser } from 'protractor';
+import { browser, Key } from 'protractor';
 import {
   createStoryUrl,
   waitForVisibilityOf,
@@ -24,17 +24,21 @@ describe('RadioButton', () => {
     driver = radioButtonTestkitFactory({ dataHook: boxThemeDataHook });
     await waitForVisibilityOf(
       await driver.element(),
-      'Cannot find radioButton',
+      'Cannot find radioButton'
     );
     await driver.clickInput();
+    await browser.actions().sendKeys(Key.ARROW_DOWN, Key.ARROW_UP);
+    expect(await driver.isFocused()).toBeTruthy();
   });
 
   eyes.it('should show the correct design on focus theme default', async () => {
     driver = radioButtonTestkitFactory({ dataHook: defaultThemeDataHook });
     await waitForVisibilityOf(
       await driver.element(),
-      'Cannot find radioButton',
+      'Cannot find radioButton'
     );
     await driver.clickInput();
+    await browser.actions().sendKeys(Key.ARROW_DOWN, Key.ARROW_UP);
+    expect(await driver.isFocused()).toBeTruthy();
   });
 });

--- a/src/components/RadioButton/RadioButton.spec.tsx
+++ b/src/components/RadioButton/RadioButton.spec.tsx
@@ -33,13 +33,7 @@ describe('RadioButton', () => {
     expect(await driver.isDisabled()).toBeTruthy();
   });
 
-  it('should have focus state', async () => {
-    const driver = createDriver(<RadioButton {...defProps} />);
-    await driver.clickInput();
-    expect(await driver.isFocused()).toBeTruthy();
-  });
-
-  it('should lose have focus state on blur', async () => {
+  it('should lose focus state on blur', async () => {
     const driver = createDriver(<RadioButton {...defProps} />);
     await driver.clickInput();
     expect(await driver.isFocused()).toBeTruthy();

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -150,9 +150,9 @@ export class RadioButton extends React.Component<
   }
 
   _getAriaLabel = () => {
-    const {label} = this.props;
+    const { label } = this.props;
     return this.props['aria-label'] ? this.props['aria-label'] : label;
-  }
+  };
 
   _getContent = (suffix: string, label: string, children: React.ReactNode) => {
     if (children) {

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -135,7 +135,7 @@ export class RadioButton extends React.Component<
           disabled={disabled}
           tabIndex={0}
           value={value}
-          onFocus={this._onFocus}
+          onFocusByKeyboard={this._onFocus}
           onBlur={this._onBlur}
           label={this._getContent(suffix, label, children)}
           name={name}

--- a/src/components/RadioButton/docs/RadioButtonTestStory.tsx
+++ b/src/components/RadioButton/docs/RadioButtonTestStory.tsx
@@ -6,9 +6,8 @@ const kind = 'Tests';
 
 function renderTest(props?: any) {
   return (
-    <div style={{ margin: '10px', maxWidth: 200 }}>
-      <div>
-        <RadioButton
+    <>
+    <RadioButton
           value={'Checked'}
           checked
           withFocusRing
@@ -17,8 +16,6 @@ function renderTest(props?: any) {
           label="box theme"
           data-hook="radio-button-box"
         />
-      </div>
-      <div style={{ marginTop: '50px' }}>
         <RadioButton
           value={'Checked'}
           checked
@@ -28,8 +25,7 @@ function renderTest(props?: any) {
           label="default theme"
           data-hook="radio-button-default"
         />
-      </div>
-    </div>
+    </>
   );
 }
 

--- a/src/components/RadioButton/docs/RadioButtonTestStory.tsx
+++ b/src/components/RadioButton/docs/RadioButtonTestStory.tsx
@@ -6,26 +6,30 @@ const kind = 'Tests';
 
 function renderTest(props?: any) {
   return (
-    <>
-    <RadioButton
-          value={'Checked'}
-          checked
-          withFocusRing
-          onChange={(val) => console.log(val)}
-          theme={RadioButtonTheme.Box}
-          label="box theme"
-          data-hook="radio-button-box"
-        />
-        <RadioButton
-          value={'Checked'}
-          checked
-          withFocusRing
-          onChange={(val) => console.log(val)}
-          theme={RadioButtonTheme.Default}
-          label="default theme"
-          data-hook="radio-button-default"
-        />
-    </>
+    <div style={{ margin: '10px', maxWidth: 200 }}>
+    <div>
+      <RadioButton
+        value={'Checked'}
+        checked
+        withFocusRing
+        onChange={(val) => console.log(val)}
+        theme={RadioButtonTheme.Box}
+        label="box theme"
+        data-hook="radio-button-box"
+      />
+    </div>
+    <div style={{ marginTop: '50px' }}>
+      <RadioButton
+        value={'Checked'}
+        checked
+        withFocusRing
+        onChange={(val) => console.log(val)}
+        theme={RadioButtonTheme.Default}
+        label="default theme"
+        data-hook="radio-button-default"
+      />
+    </div>
+  </div>
   );
 }
 


### PR DESCRIPTION
The desired improvement - changing the focus ring so it'd not appear after every mouse click (only from keyboard).