### PR TITLE
build: configure Prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,5 +173,9 @@
   "yoshi": {
     "exports": "wix-ui-tpa",
     "tpaStyle": true
+  },
+  "prettier": {
+    "singleQuote": true,
+    "trailingComma": "all"
   }
 }


### PR DESCRIPTION
This PR adds a basic Prettier configuration to avoid conflicts after committing - inspired by [WSR solution](https://github.com/wix/wix-style-react/blob/master/.prettierrc.js#L1-L5).

I didn't add `arrowParens` since I don't see the source code is formatted like that in wix-ui-tpa after committing.