### PR TITLE
Image - support aspectRatio prop

### DIFF
--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -4,16 +4,16 @@ import { MediaImage } from 'wix-ui-core/media-image';
 import { TPAComponentProps } from '../../types';
 import { classes, st } from './Image.st.css';
 
-const enum AspectRatioOptions {
-  square = 1,
-  cinema = 16 / 9,
-  landscape = 4 / 3,
-}
-
 const enum ResizeOptions {
   contain = 'contain',
   cover = 'cover',
 }
+
+const AspectRatioOptions = {
+  square: 1,
+  cinema: 16 / 9,
+  landscape: 4 / 3,
+};
 
 export interface ImageProps extends TPAComponentProps {
   /** The source could be any absolute full URL or a relative URI of a media platform item */
@@ -31,7 +31,7 @@ export interface ImageProps extends TPAComponentProps {
   /** Specifies how the image is resized to fit its container */
   resize?: 'contain' | 'cover';
   // Specifies the proportional relationship between width and height
-  aspectRatio?: '1:1' | '16:9' | '4:3' | number;
+  aspectRatio?: 'square' | 'cinema' | 'landscape' | number;
   /** An experience to set while the image is fetched and loaded  */
   loadingBehavior?: 'none' | 'blur';
 }
@@ -107,7 +107,9 @@ export class Image extends React.Component<ImageProps> {
     const isAbsoluteUrl = src && src.match('^https?://');
 
     const aspectRatioAsNumber =
-      typeof aspectRatio === 'number' ? aspectRatio : 1;
+      typeof aspectRatio === 'number'
+        ? aspectRatio
+        : AspectRatioOptions[aspectRatio];
     const sourceDimensions = { width, height };
     const containerDimensions = {
       width:

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -28,10 +28,10 @@ export interface ImageProps extends TPAComponentProps {
   onLoad?: React.EventHandler<React.SyntheticEvent>;
   /** A callback to be called if error occurs while loading */
   onError?: React.EventHandler<React.SyntheticEvent>;
-  // Specifies the proportional relationship between width and height
-  aspectRatio?: '1:1' | '16:9' | '4:3' | number;
   /** Specifies how the image is resized to fit its container */
   resize?: 'contain' | 'cover';
+  // Specifies the proportional relationship between width and height
+  aspectRatio?: '1:1' | '16:9' | '4:3' | number;
   /** An experience to set while the image is fetched and loaded  */
   loadingBehavior?: 'none' | 'blur';
 }
@@ -74,8 +74,8 @@ const Placeholder = ({
 export class Image extends React.Component<ImageProps> {
   static displayName = 'Image';
   static defaultProps: DefaultProps = {
-    aspectRatio: 1,
     resize: ResizeOptions.contain,
+    aspectRatio: 1,
   };
 
   state = { isLoaded: false };
@@ -110,8 +110,10 @@ export class Image extends React.Component<ImageProps> {
       typeof aspectRatio === 'number' ? aspectRatio : 1;
     const sourceDimensions = { width, height };
     const containerDimensions = {
-      width,
-      height: width / aspectRatioAsNumber,
+      width:
+        !width && aspectRatioAsNumber ? height * aspectRatioAsNumber : width,
+      height:
+        !height && aspectRatioAsNumber ? width / aspectRatioAsNumber : height,
     };
 
     const hasLoadingBehavior = loadingBehavior === 'blur';

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -36,7 +36,7 @@ export interface ImageProps extends TPAComponentProps {
   loadingBehavior?: 'none' | 'blur';
 }
 
-type DefaultProps = Pick<ImageProps, 'aspectRatio' | 'resize'>;
+type DefaultProps = Pick<ImageProps, 'resize' | 'aspectRatio'>;
 
 interface Dimensions {
   width: ImageProps['width'];

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -111,11 +111,16 @@ export class Image extends React.Component<ImageProps> {
         ? aspectRatio
         : AspectRatioOptions[aspectRatio];
     const sourceDimensions = { width, height };
+
     const containerDimensions = {
       width:
-        !width && aspectRatioAsNumber ? height * aspectRatioAsNumber : width,
+        !width && height && aspectRatioAsNumber
+          ? height * aspectRatioAsNumber
+          : width,
       height:
-        !height && aspectRatioAsNumber ? width / aspectRatioAsNumber : height,
+        !height && width && aspectRatioAsNumber
+          ? width / aspectRatioAsNumber
+          : height,
     };
 
     const hasLoadingBehavior = loadingBehavior === 'blur';

--- a/src/components/Image/Image.visual.tsx
+++ b/src/components/Image/Image.visual.tsx
@@ -61,41 +61,17 @@ visualize('Image', () => {
       ));
 
       story('with aspectRatio', () => {
-        snap('as 1:1', (done) => (
-          <Image
-            src={src}
-            width={480}
-            height={360}
-            aspectRatio="1:1"
-            onLoad={done}
-          />
+        snap('as square', (done) => (
+          <Image src={src} width={480} aspectRatio="square" onLoad={done} />
         ));
-        snap('as 16:9', (done) => (
-          <Image
-            src={src}
-            width={480}
-            height={360}
-            aspectRatio="16:9"
-            onLoad={done}
-          />
+        snap('as cinema', (done) => (
+          <Image src={src} width={480} aspectRatio="cinema" onLoad={done} />
         ));
-        snap('as 4:3', (done) => (
-          <Image
-            src={src}
-            width={480}
-            height={360}
-            aspectRatio="4:3"
-            onLoad={done}
-          />
+        snap('as landscape', (done) => (
+          <Image src={src} width={480} aspectRatio="landscape" onLoad={done} />
         ));
         snap('as custom number', (done) => (
-          <Image
-            src={src}
-            width={480}
-            height={360}
-            aspectRatio={1.5}
-            onLoad={done}
-          />
+          <Image src={src} width={480} aspectRatio={1.5} onLoad={done} />
         ));
       });
 

--- a/src/components/Image/Image.visual.tsx
+++ b/src/components/Image/Image.visual.tsx
@@ -60,6 +60,45 @@ visualize('Image', () => {
         />
       ));
 
+      story('with aspectRatio', () => {
+        snap('as 1:1', (done) => (
+          <Image
+            src={src}
+            width={480}
+            height={360}
+            aspectRatio="1:1"
+            onLoad={done}
+          />
+        ));
+        snap('as 16:9', (done) => (
+          <Image
+            src={src}
+            width={480}
+            height={360}
+            aspectRatio="16:9"
+            onLoad={done}
+          />
+        ));
+        snap('as 4:3', (done) => (
+          <Image
+            src={src}
+            width={480}
+            height={360}
+            aspectRatio="4:3"
+            onLoad={done}
+          />
+        ));
+        snap('as custom number', (done) => (
+          <Image
+            src={src}
+            width={480}
+            height={360}
+            aspectRatio={1.5}
+            onLoad={done}
+          />
+        ));
+      });
+
       story('with resize', () => {
         snap('as contain', (done) => (
           <Image

--- a/src/components/Image/docs/examples.ts
+++ b/src/components/Image/docs/examples.ts
@@ -51,7 +51,7 @@ export const aspectRatioExample = `
     width="300"
     alt="Garfield smiles and puts his hand over chest"
     resize="cover"
-    aspectRatio={1.777}
+    aspectRatio="cinema"
   />
   <Image
     src="c5f754_dd75514d14fa4057b4f4a6cc8ce7add3~mv2.jpg"

--- a/src/components/Image/docs/examples.ts
+++ b/src/components/Image/docs/examples.ts
@@ -37,6 +37,32 @@ export const resizingExample = `
 </div>
 `;
 
+export const aspectRatioExample = `
+<div style={{ display: 'flex', justifyContent: 'space-evenly' }}>
+  <Image
+    src="c5f754_dd75514d14fa4057b4f4a6cc8ce7add3~mv2.jpg"
+    width="300"
+    alt="Garfield smiles and puts his hand over chest"
+    resize="cover"
+    aspectRatio={1}
+  />
+  <Image
+    src="c5f754_dd75514d14fa4057b4f4a6cc8ce7add3~mv2.jpg"
+    width="300"
+    alt="Garfield smiles and puts his hand over chest"
+    resize="cover"
+    aspectRatio={1.777}
+  />
+  <Image
+    src="c5f754_dd75514d14fa4057b4f4a6cc8ce7add3~mv2.jpg"
+    width="300"
+    alt="Garfield smiles and puts his hand over chest"
+    resize="cover"
+    aspectRatio={1.333}
+  />
+</div>
+`;
+
 export const blurLoadingExample = `
 class MediaImageWithBlurryLoading extends React.Component {
   state = {

--- a/src/components/Image/docs/index.story.tsx
+++ b/src/components/Image/docs/index.story.tsx
@@ -83,7 +83,7 @@ export default {
             {
               title: 'Aspect Ratio',
               description:
-                'The proportional relationship between width and height of the image can be adjusted using the `aspectRatio`.',
+                'The proportional relationship between width and height of the image can be adjusted using `aspectRatio`. The prop also supports predefined values in order to apply their ratio - such as: `square`, `cinema` and `landscape`.',
               source: examples.aspectRatioExample,
             },
             {

--- a/src/components/Image/docs/index.story.tsx
+++ b/src/components/Image/docs/index.story.tsx
@@ -81,6 +81,12 @@ export default {
               source: examples.resizingExample,
             },
             {
+              title: 'Aspect Ratio',
+              description:
+                'The proportional relationship between width and height of the image can be adjusted using the `aspectRatio`.',
+              source: examples.aspectRatioExample,
+            },
+            {
               title: 'Blurry Loading',
               description:
                 'The image can be loaded progressively with a blur placeholder by setting the `loadingBehavior` as `blur`. Important to mention that an actual progressive loading would work only for a relative media image, whereas for an absolute image it would just have the same effect (but the image will not be loaded progressively). Also notice that the wrapper class and the button are only to allow simulating the behavior again easily.',


### PR DESCRIPTION
<!--
  Thanks for creating a pull request to `wix-ui-tpa`!

  =========================
   Before creating the PR:
  =========================
  
    - Please make sure your commits are signed,the PR cannot be merged without it.
      Read more about it here:
      https://github.com/wix/wix-style-react/blob/master/docs/contribution/CREATE_PR.md#sign-commits
      
    - If the PR changes/adds something to the UI, make sure it's aligned to the design system specs:
      https://zeroheight.com/7sjjzhgo2/p/7181b5-tpa-design-system
      
  -->

# ✨ Pull Request

### 💁 Description

<!---
  Tell us what this PR is supposed to solve, add a link to related
  issues/tasks from Zeplin/Notion/Jira/Github issue if relevant. 
  e.g 
  "Implement new component ShinyNewComponent"
-->

This PR implements the aspectRatio prop for `Image`.

We should decide how to manage and infer the dimensions (it's not in the scope of this task but it might change the implementation of `aspectRatio` later).

### 👀  PR is ready for review 

<!-- mark checkbox to let reviewers know you're ready -->

- [X] Ready for review
