### PR TITLE
Radio button remove focus ring on mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "lodash": "^4.17.11",
     "normalize-scroll-left": "^0.2.1",
     "react-resize-detector": "^4.1.3",
-    "wix-style-react": "^9.47.0",
+    "wix-style-react": "9.68.0",
     "wix-ui-core": "^3.0.150",
     "wix-ui-icons-common": "^2.0.0",
     "yoshi-stylable-dependencies": "^4.86.0",

--- a/src/components/RadioButton/RadioButton.e2e.ts
+++ b/src/components/RadioButton/RadioButton.e2e.ts
@@ -14,6 +14,7 @@ describe('RadioButton', () => {
   });
   const defaultThemeDataHook = 'radio-button-default';
   const boxThemeDataHook = 'radio-button-box';
+  const defaultThemeMobileDataHook = 'radio-button-default-mobile';
   let driver;
 
   beforeEach(async () => {
@@ -40,5 +41,15 @@ describe('RadioButton', () => {
     await driver.clickInput();
     await browser.actions().sendKeys(Key.ARROW_DOWN, Key.ARROW_UP);
     expect(await driver.isFocused()).toBeTruthy();
+  });
+
+  eyes.it('should show the correct design on focus theme default on mobile', async () => {
+    driver = radioButtonTestkitFactory({ dataHook: defaultThemeMobileDataHook });
+    await waitForVisibilityOf(
+      await driver.element(),
+      'Cannot find radioButton',
+    );
+    await driver.clickInput();
+    await browser.actions().sendKeys(Key.ARROW_DOWN, Key.ARROW_UP);
   });
 });

--- a/src/components/RadioButton/RadioButton.e2e.ts
+++ b/src/components/RadioButton/RadioButton.e2e.ts
@@ -43,13 +43,18 @@ describe('RadioButton', () => {
     expect(await driver.isFocused()).toBeTruthy();
   });
 
-  eyes.it('should show the correct design on focus theme default on mobile', async () => {
-    driver = radioButtonTestkitFactory({ dataHook: defaultThemeMobileDataHook });
-    await waitForVisibilityOf(
-      await driver.element(),
-      'Cannot find radioButton',
-    );
-    await driver.clickInput();
-    await browser.actions().sendKeys(Key.ARROW_DOWN, Key.ARROW_UP);
-  });
+  eyes.it(
+    'should show the correct design on focus theme default on mobile',
+    async () => {
+      driver = radioButtonTestkitFactory({
+        dataHook: defaultThemeMobileDataHook,
+      });
+      await waitForVisibilityOf(
+        await driver.element(),
+        'Cannot find radioButton',
+      );
+      await driver.clickInput();
+      await browser.actions().sendKeys(Key.ARROW_DOWN, Key.ARROW_UP);
+    },
+  );
 });

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -114,9 +114,15 @@ export class RadioButton extends React.Component<
     const { mobile: isMobile } = this.context;
 
     const focusedIcon =
-      !isMobile && withFocusRing && this.state.focused && theme === RadioButtonTheme.Default;
+      !isMobile &&
+      withFocusRing &&
+      this.state.focused &&
+      theme === RadioButtonTheme.Default;
     const focusedBox =
-      !isMobile && withFocusRing && this.state.focused && theme === RadioButtonTheme.Box;
+      !isMobile &&
+      withFocusRing &&
+      this.state.focused &&
+      theme === RadioButtonTheme.Box;
 
     return (
       <div

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -6,6 +6,7 @@ import {
 import { RADIOBUTTON_DATA_KEYS, RADIOBUTTON_DATA_HOOKS } from './dataHooks';
 import { st, classes } from './RadioButton.st.css';
 import classnames from 'classnames';
+import { TPAComponentsContext } from '../TPAComponentsConfig';
 
 export interface RadioButtonChangeEvent
   extends React.MouseEvent<HTMLDivElement> {
@@ -70,6 +71,7 @@ export class RadioButton extends React.Component<
   RadioButtonState
 > {
   static displayName = 'RadioButton';
+  static contextType = TPAComponentsContext;
   static defaultProps: DefaultProps = {
     withFocusRing: false,
     checked: false,
@@ -108,10 +110,13 @@ export class RadioButton extends React.Component<
       withFocusRing,
       children,
     } = this.props;
+
+    const { mobile: isMobile } = this.context;
+
     const focusedIcon =
-      withFocusRing && this.state.focused && theme === RadioButtonTheme.Default;
+      !isMobile && withFocusRing && this.state.focused && theme === RadioButtonTheme.Default;
     const focusedBox =
-      withFocusRing && this.state.focused && theme === RadioButtonTheme.Box;
+      !isMobile && withFocusRing && this.state.focused && theme === RadioButtonTheme.Box;
 
     return (
       <div

--- a/src/components/RadioButton/docs/RadioButtonTestStory.tsx
+++ b/src/components/RadioButton/docs/RadioButtonTestStory.tsx
@@ -1,6 +1,6 @@
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
-import { TPAComponentsWrapper } from 'src/test/utils';
+import { TPAComponentsWrapper } from '../../../test/utils';
 import { RadioButton, RadioButtonTheme } from '..';
 
 const kind = 'Tests';

--- a/src/components/RadioButton/docs/RadioButtonTestStory.tsx
+++ b/src/components/RadioButton/docs/RadioButtonTestStory.tsx
@@ -38,7 +38,7 @@ function renderTest(props?: any) {
             withFocusRing
             onChange={(val) => console.log(val)}
             theme={RadioButtonTheme.Default}
-            label="default theme"
+            label="no focus-ring on mobile"
             data-hook="radio-button-default-mobile"
           />,
         )}

--- a/src/components/RadioButton/docs/RadioButtonTestStory.tsx
+++ b/src/components/RadioButton/docs/RadioButtonTestStory.tsx
@@ -31,17 +31,17 @@ function renderTest(props?: any) {
         />
       </div>
       <div style={{ marginTop: '50px' }}>
-      {TPAComponentsWrapper({ mobile: true })(
-        <RadioButton
-          value={'Checked'}
-          checked
-          withFocusRing
-          onChange={(val) => console.log(val)}
-          theme={RadioButtonTheme.Default}
-          label="default theme"
-          data-hook="radio-button-default-mobile"
-        />
-      )}
+        {TPAComponentsWrapper({ mobile: true })(
+          <RadioButton
+            value={'Checked'}
+            checked
+            withFocusRing
+            onChange={(val) => console.log(val)}
+            theme={RadioButtonTheme.Default}
+            label="default theme"
+            data-hook="radio-button-default-mobile"
+          />,
+        )}
       </div>
     </div>
   );

--- a/src/components/RadioButton/docs/RadioButtonTestStory.tsx
+++ b/src/components/RadioButton/docs/RadioButtonTestStory.tsx
@@ -1,5 +1,6 @@
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
+import { TPAComponentsWrapper } from 'src/test/utils';
 import { RadioButton, RadioButtonTheme } from '..';
 
 const kind = 'Tests';
@@ -28,6 +29,19 @@ function renderTest(props?: any) {
           label="default theme"
           data-hook="radio-button-default"
         />
+      </div>
+      <div style={{ marginTop: '50px' }}>
+      {TPAComponentsWrapper({ mobile: true })(
+        <RadioButton
+          value={'Checked'}
+          checked
+          withFocusRing
+          onChange={(val) => console.log(val)}
+          theme={RadioButtonTheme.Default}
+          label="default theme"
+          data-hook="radio-button-default-mobile"
+        />
+      )}
       </div>
     </div>
   );


### PR DESCRIPTION
<!--
  Thanks for creating a pull request to `wix-ui-tpa`!

  =========================
   Before creating the PR:
  =========================
  
    - Please make sure your commits are signed,the PR cannot be merged without it.
      Read more about it here:
      https://github.com/wix/wix-style-react/blob/master/docs/contribution/CREATE_PR.md#sign-commits
      
    - If the PR changes/adds something to the UI, make sure it's aligned to the design system specs:
      https://zeroheight.com/7sjjzhgo2/p/7181b5-tpa-design-system
      
  -->

# ✨ Pull Request

### 💁 Description

We'd like to use the radioButton component but we get a focus ring on mobile after a regular tapping which looks odd. 
More details available here -> https://jira.wixpress.com/browse/EE-28048.

...

### 💭 Motivation

Using TPAComponentsContext was suggested as a relatively immediate and simple solution. We'd be happy to unblock this problem so we'd be able to use the component.

...


### ☝️ TODOs <!-- optional -->

<!---
  List leftover tasks, related PR's blocking this etc...
  e.g
  "- [ ] waiting for PR merge in wix-ui-core"
  ...
  -->
...

### 👀  PR is ready for review 

<!-- mark checkbox to let reviewers know you're ready -->

- [ ] Ready for review
