### PR TITLE
"fix" port issue in concurrent tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test": "concurrently npm:lint npm:test:unit npm:test:e2e npm:test:eyes-storybook npm:autotools npm:test:perfer-bundles",
     "test:watch": "yoshi test --jest --watch",
     "test:unit": "yoshi test --jest",
-    "test:e2e": "yoshi test --protractor",
+    "test:e2e": "yoshi test --protractor --debug=3201",
     "test:eyes-storybook": "if test \"$EYES_API_KEY\"; then npm run test:eyes-storybook:local ; fi",
     "test:eyes-storybook:local": "eyes-storybook -c ./.storybook-test -s ./.storybook-test/public",
     "test:perfer-bundles": "npm run build:perfer-bundles && perfer --verbose",
@@ -173,6 +173,11 @@
   },
   "yoshi": {
     "exports": "wix-ui-tpa",
-    "tpaStyle": true
+    "tpaStyle": true,
+    "servers": {
+      "cdn": {
+        "port": 3201
+      }
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test": "concurrently npm:lint npm:test:unit npm:test:e2e npm:test:eyes-storybook npm:autotools npm:test:perfer-bundles",
     "test:watch": "yoshi test --jest --watch",
     "test:unit": "yoshi test --jest",
-    "test:e2e": "yoshi test --protractor --debug=3201",
+    "test:e2e": "yoshi test --protractor",
     "test:eyes-storybook": "if test \"$EYES_API_KEY\"; then npm run test:eyes-storybook:local ; fi",
     "test:eyes-storybook:local": "eyes-storybook -c ./.storybook-test -s ./.storybook-test/public",
     "test:perfer-bundles": "npm run build:perfer-bundles && perfer --verbose",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "postbuild": "import-path --path src/components --dts",
     "pr-postbuild": "npm run storybook:release",
     "pretest": "./scripts/ensure-build.sh",
-    "test": "concurrently npm:lint npm:test:unit npm:test:e2e npm:test:eyes-storybook npm:autotools npm:test:perfer-bundles",
+    "test": "npm run test:unit && concurrently npm:lint npm:test:e2e npm:test:eyes-storybook npm:autotools npm:test:perfer-bundles",
     "test:watch": "yoshi test --jest --watch",
     "test:unit": "yoshi test --jest",
     "test:e2e": "yoshi test --protractor",
@@ -173,11 +173,6 @@
   },
   "yoshi": {
     "exports": "wix-ui-tpa",
-    "tpaStyle": true,
-    "servers": {
-      "cdn": {
-        "port": 3201
-      }
-    }
+    "tpaStyle": true
   }
 }


### PR DESCRIPTION
Trying to reduce flakiness by moving the unit tests out of the concurrent process, so that we won't have port collisions.

### 👀  PR is ready for review 

<!-- mark checkbox to let reviewers know you're ready -->

- [x] Ready for review
