### PR TITLE
fix(Playground): use image media item

### DIFF
--- a/stories/Playground/example.tsx
+++ b/stories/Playground/example.tsx
@@ -35,7 +35,7 @@ import * as React from "react";
             <Image
               width={400}
               height={520}
-              src="./product.png"
+              src="c5f754_23cf5dfa1ea44dc09e87a03df0996f83~mv2.png"
               alt="Product Image"
             />
           </Card.Container>


### PR DESCRIPTION
<!--
  Thanks for creating a pull request to `wix-ui-tpa`!

  =========================
   Before creating the PR:
  =========================
  
    - Please make sure your commits are signed,the PR cannot be merged without it.
      Read more about it here:
      https://github.com/wix/wix-style-react/blob/master/docs/contribution/CREATE_PR.md#sign-commits
      
    - If the PR changes/adds something to the UI, make sure it's aligned to the design system specs:
      https://zeroheight.com/7sjjzhgo2/p/7181b5-tpa-design-system
      
  -->

# ✨ Pull Request

### 💁 Description

This PR fixes the image in the playground example:
![image](https://user-images.githubusercontent.com/7141972/105632596-adc05f80-5e5c-11eb-992f-00f80aef658b.png)

Actually we'd also like to change these places:
https://github.com/wix/wix-ui-tpa/blob/master/src/components/Card/docs/examples.tsx#L3
https://github.com/wix/wix-ui-tpa/blob/master/src/components/Card/docs/index.story.tsx#L37

But I think it's a little early (maybe after the first integration?)

### 👀  PR is ready for review 

<!-- mark checkbox to let reviewers know you're ready -->

- [X] Ready for review
