### PR TITLE
Image - change default resize to cover

### DIFF
--- a/src/components/HeroImage/HeroImage.tsx
+++ b/src/components/HeroImage/HeroImage.tsx
@@ -1,11 +1,16 @@
 import * as React from 'react';
-import { Image } from '../Image';
+import { Image, ResizeOptions } from '../Image';
 import { classes, st } from './HeroImage.st.css';
 import { HeroImageProps } from './types';
+
+type DefaultProps = Pick<HeroImageProps, 'resize'>;
 
 /** HeroImage is a component representing a header with high presence providing context about the page content */
 export class HeroImage extends React.Component<HeroImageProps> {
   static displayName = 'HeroImage';
+  static defaultProps: DefaultProps = {
+    resize: ResizeOptions.cover,
+  };
 
   render() {
     const { className, ...imageProps } = this.props;

--- a/src/components/ThumbnailImage/ThumbnailImage.tsx
+++ b/src/components/ThumbnailImage/ThumbnailImage.tsx
@@ -1,11 +1,16 @@
 import * as React from 'react';
-import { Image } from '../Image';
+import { Image, ResizeOptions } from '../Image';
 import { classes, st } from './ThumbnailImage.st.css';
 import { ThumbnailImageProps } from './types';
+
+type DefaultProps = Pick<ThumbnailImageProps, 'resize'>;
 
 /** ThumbnailImage is a component representing a relativity small image that typically act as target leading to a primary content (page/flow) */
 export class ThumbnailImage extends React.Component<ThumbnailImageProps> {
   static displayName = 'ThumbnailImage';
+  static defaultProps: DefaultProps = {
+    resize: ResizeOptions.cover,
+  };
 
   render() {
     const { className, ...imageProps } = this.props;


### PR DESCRIPTION
<!--
  Thanks for creating a pull request to `wix-ui-tpa`!

  =========================
   Before creating the PR:
  =========================
  
    - Please make sure your commits are signed,the PR cannot be merged without it.
      Read more about it here:
      https://github.com/wix/wix-style-react/blob/master/docs/contribution/CREATE_PR.md#sign-commits
      
    - If the PR changes/adds something to the UI, make sure it's aligned to the design system specs:
      https://zeroheight.com/7sjjzhgo2/p/7181b5-tpa-design-system
      
  -->

# ✨ Pull Request

### 💁 Description

This PR changes the default resize value to `cover` in HeroImage and ThumbnailImage. This is a product decision from @michalvardi , since it would be the case most of the time (according to the product research).

Notice that `contains` still remains the default value in the case of Image, and we think it's okay (the idea is to see the full image in generic cases).

### 👀  PR is ready for review 

<!-- mark checkbox to let reviewers know you're ready -->

- [X] Ready for review
