### PR TITLE
fix(Popover): Stylable warning 

### DIFF
--- a/src/components/Popover/docs/PopoverWiringExample.st.css
+++ b/src/components/Popover/docs/PopoverWiringExample.st.css
@@ -5,6 +5,6 @@
 
 .root {
   -st-mixin: overrideStyleParams(
-    BackgroundColor ''"color(--BackgroundOverride)"''
+    BackgroundColor '"color(--BackgroundOverride)"'
   );
 }


### PR DESCRIPTION
<!--
  Thanks for creating a pull request to `wix-ui-tpa`!

  =========================
   Before creating the PR:
  =========================
  
    - Please make sure your commits are signed,the PR cannot be merged without it.
      Read more about it here:
      https://github.com/wix/wix-style-react/blob/master/docs/contribution/CREATE_PR.md#sign-commits
      
    - If the PR changes/adds something to the UI, make sure it's aligned to the design system specs:
      https://zeroheight.com/7sjjzhgo2/p/7181b5-tpa-design-system
      
  -->

# ✨ Pull Request

### 💁 Description

This PR fixes the following warning once starting Storybook (it happens only on startup):
```bash
WARNING in Stylable: /Users/nitayn/dev/wix-ui-tpa/src/components/Popover/docs/PopoverWiringExample.st.css:8:24: cannot find native function or custom formatter called color

   6 | .root {
   7 |   -st-mixin: overrideStyleParams(
>  8 |     BackgroundColor ''"color(--BackgroundOverride)"''
     |                        ^
   9 |   );
  10 | }
```

### 👀  PR is ready for review 

<!-- mark checkbox to let reviewers know you're ready -->

- [X] Ready for review
