### PR TITLE
Radio Button - box border should change from 60% to 100% both on hover and focus

### DIFF
--- a/src/components/RadioButton/RadioButton.st.css
+++ b/src/components/RadioButton/RadioButton.st.css
@@ -198,16 +198,9 @@
 
 /* Create the indicator (the dot/circle - hidden when not checked) */
 
-.root:box:hover:checked .wrapper {
-    border-color: applyOpacity(value(CurrentIconColor), 1);
-}
 
 .root:box:hover:not(:checked) .wrapper {
     border-color: applyOpacity(value(CurrentBorderColor), 1);
-}
-
-.root:box:focus-within .wrapper {
-    border-color: applyOpacity(value(CurrentIconColor), 1);
 }
 
 .root:hover .radioIcon {

--- a/src/components/RadioButton/RadioButton.st.css
+++ b/src/components/RadioButton/RadioButton.st.css
@@ -198,7 +198,23 @@
 
 /* Create the indicator (the dot/circle - hidden when not checked) */
 
+.root:box:hover:checked .wrapper {
+    border-color: applyOpacity(value(CurrentIconColor), 1);
+}
+
+.root:box:hover:not(:checked) .wrapper {
+    border-color: applyOpacity(value(CurrentBorderColor), 1);
+}
+
+.root:box:focus-within .wrapper {
+    border-color: applyOpacity(value(CurrentIconColor), 1);
+}
+
 .root:hover .radioIcon {
+    border-color: applyOpacity(value(CurrentBorderColor), 1);
+}
+
+.root:focus-within .radioIcon {
     border-color: applyOpacity(value(CurrentBorderColor), 1);
 }
 

--- a/src/components/RadioButton/RadioButton.st.css
+++ b/src/components/RadioButton/RadioButton.st.css
@@ -201,14 +201,17 @@
 
 .root:box:hover:not(:checked) .wrapper {
     border-color: applyOpacity(value(CurrentBorderColor), 1);
+    transition: border-color .2s ease-in-out;
 }
 
 .root:hover .radioIcon {
     border-color: applyOpacity(value(CurrentBorderColor), 1);
+    transition: border-color .2s ease-in-out;
 }
 
 .root:focus-within .radioIcon {
     border-color: applyOpacity(value(CurrentBorderColor), 1);
+    transition: border-color .2s ease-in-out;
 }
 
 .root:checked .innerCheck {


### PR DESCRIPTION


# ✨ Pull Request

### 💁 Description
The box border should change from 60% to 100% both on hover and focus.
See comment on [EE-28048](https://jira.wixpress.com/browse/EE-28048?focusedCommentId=8601528&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel)

...

### 💭 Motivation

Would like to migrate to radio button at our project.
...


### ☝️ TODOs <!-- optional -->

<!---
  List leftover tasks, related PR's blocking this etc...
  e.g
  "- [ ] waiting for PR merge in wix-ui-core"
  ...
  -->
...

### 👀  PR is ready for review 

<!-- mark checkbox to let reviewers know you're ready -->

- [x] Ready for review
