### PR TITLE
<Dialog/> - added notFullscreenOnMobile prop for mobile

### DIFF
--- a/.storybook-test/config.js
+++ b/.storybook-test/config.js
@@ -4,7 +4,7 @@ import { init } from '../test/visual/StyleProcessorUtil';
 
 function loadStories() {
   require('../mocks');
-
+  require('../stories/utils/MobilePageStory');
   const req = require.context('../src', true, /\.visual\.tsx$/);
   req.keys().forEach(filename => req(filename));
 

--- a/src/components/Dialog/Dialog.st.css
+++ b/src/components/Dialog/Dialog.st.css
@@ -65,6 +65,7 @@
     display: flex;
     align-items: center;
     position:absolute;
+    overflow: hidden;
 
     top: value(NotFullscreenMobilePadding);
     left: value(NotFullscreenMobilePadding);

--- a/src/components/Dialog/Dialog.st.css
+++ b/src/components/Dialog/Dialog.st.css
@@ -7,6 +7,10 @@
     -st-from: "../IconButton/IconButton.st.css";
     -st-named: skin-line;
 }
+/*Constants*/
+:vars {
+    NotFullscreenMobilePadding: 20px;
+}
 
 /*Overrides*/
 :vars {
@@ -23,7 +27,7 @@
 }
 
 .root {
-    -st-states: mobile, rtl, wired;
+    -st-states: mobile, rtl, wired, notFullscreenMobile;
 }
 
 .contentWrapper {
@@ -55,6 +59,24 @@
     width: 100%;
     height: 100%;
     transform: none;
+}
+
+.root:mobile:notFullscreenMobile .outerContentWrapper {
+    display: flex;
+    align-items: center;
+    position:absolute;
+
+    top: value(NotFullscreenMobilePadding);
+    left: value(NotFullscreenMobilePadding);
+    width: calc(100% - 2 * value(NotFullscreenMobilePadding));
+    height: calc(100% - 2 * value(NotFullscreenMobilePadding));
+}
+
+.root:mobile:notFullscreenMobile .contentWrapper{
+    position: relative;
+    height: auto;
+    max-height: 440px;
+    min-width: auto;
 }
 
 .root:rtl .closeButtonWrapper {

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -94,9 +94,7 @@ export class Dialog extends React.Component<DialogProps> {
             >
               <div className={classes.outerContentWrapper}>
                 <div
-                  className={`${classes.contentWrapper} ${
-                    contentClassName || ''
-                  }`}
+                  className={`${classes.contentWrapper} ${contentClassName || ''}`}
                   role="dialog"
                   aria-modal="true"
                   aria-label={ariaLabel}

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -32,11 +32,14 @@ export interface DialogProps extends TPAComponentProps {
   closeButtonAriaLabelledby?: string;
   /** Whether the Dialog is wired to the site palette, or has a white background */
   wiredToSiteColors?: boolean;
+  /** Determines whether Dialog should open in a non-fullscreen mode on mobile */
+  notFullscreenOnMobile?: boolean;
 }
 
 interface DefaultProps {
   isOpen: boolean;
   manualFocus: boolean;
+  notFullscreenOnMobile: boolean;
 }
 
 /** Dialog */
@@ -45,6 +48,7 @@ export class Dialog extends React.Component<DialogProps> {
   static defaultProps: DefaultProps = {
     isOpen: false,
     manualFocus: false,
+    notFullscreenOnMobile: false,
   };
 
   render() {
@@ -62,6 +66,7 @@ export class Dialog extends React.Component<DialogProps> {
       closeButtonAriaLabel,
       closeButtonAriaLabelledby,
       wiredToSiteColors,
+      notFullscreenOnMobile,
     } = this.props;
 
     return (
@@ -70,7 +75,12 @@ export class Dialog extends React.Component<DialogProps> {
           <div
             className={st(
               classes.root,
-              { mobile, rtl, wired: wiredToSiteColors },
+              {
+                mobile,
+                rtl,
+                wired: wiredToSiteColors,
+                notFullscreenMobile: mobile && notFullscreenOnMobile,
+              },
               classes[`skin-${wiredToSiteColors ? 'wired' : 'fixed'}`],
               className,
             )}
@@ -82,28 +92,30 @@ export class Dialog extends React.Component<DialogProps> {
               focusTrap={!manualFocus}
               onRequestClose={onClose}
             >
-              <div
-                className={`${classes.contentWrapper} ${
-                  contentClassName || ''
-                }`}
-                role="dialog"
-                aria-modal="true"
-                aria-label={ariaLabel}
-                aria-labelledby={ariaLabelledBy}
-                aria-describedby={ariaDescribedBy}
-              >
-                <div className={classes.closeButtonWrapper}>
-                  <IconButton
-                    className={classes.closeIconButton}
-                    data-hook={DATA_HOOKS.CLOSE_BTN}
-                    aria-label={closeButtonAriaLabel}
-                    aria-labelledby={closeButtonAriaLabelledby}
-                    innerRef={closeButtonRef}
-                    onClick={onClose}
-                    icon={<CloseIcon />}
-                  />
+              <div className={classes.outerContentWrapper}>
+                <div
+                  className={`${classes.contentWrapper} ${
+                    contentClassName || ''
+                  }`}
+                  role="dialog"
+                  aria-modal="true"
+                  aria-label={ariaLabel}
+                  aria-labelledby={ariaLabelledBy}
+                  aria-describedby={ariaDescribedBy}
+                >
+                  <div className={classes.closeButtonWrapper}>
+                    <IconButton
+                      className={classes.closeIconButton}
+                      data-hook={DATA_HOOKS.CLOSE_BTN}
+                      aria-label={closeButtonAriaLabel}
+                      aria-labelledby={closeButtonAriaLabelledby}
+                      innerRef={closeButtonRef}
+                      onClick={onClose}
+                      icon={<CloseIcon />}
+                    />
+                  </div>
+                  <div className={classes.dialogContent}>{children}</div>
                 </div>
-                <div className={classes.dialogContent}>{children}</div>
               </div>
             </Modal>
           </div>

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -94,7 +94,9 @@ export class Dialog extends React.Component<DialogProps> {
             >
               <div className={classes.outerContentWrapper}>
                 <div
-                  className={`${classes.contentWrapper} ${contentClassName || ''}`}
+                  className={`${classes.contentWrapper} ${
+                    contentClassName || ''
+                  }`}
                   role="dialog"
                   aria-modal="true"
                   aria-label={ariaLabel}

--- a/src/components/Dialog/Dialog.visual.tsx
+++ b/src/components/Dialog/Dialog.visual.tsx
@@ -3,10 +3,46 @@ import { visualize, story, snap } from 'storybook-snapper';
 import { Dialog } from './';
 import { Text, TYPOGRAPHY } from '../Text';
 import { Button, PRIORITY } from '../Button';
-import { TPAComponentsWrapper } from '../../test/utils';
+import { VisualTestWrapper } from '../../test/visualTestWrapper';
 // import { setDarkPalette } from '../../test/visualTestUtils';
 
-const DialogWithContent = (props) => (
+const MobileDialogWithContent = props => (
+  <Dialog isOpen {...props}>
+    <div className="content" style={{ textAlign: 'center' }}>
+      <Text typography={TYPOGRAPHY.largeTitle} tagName="div">
+        Discard draft?
+      </Text>
+      <div
+        className="text-container"
+        style={{ marginTop: '16px', marginBottom: '32px' }}
+      >
+        <Text typography={TYPOGRAPHY.runningText} tagName="div">
+          Are You Sure you want to discard the changes you made?
+        </Text>
+      </div>
+      <div
+        className="primary-btn-container"
+        style={{ marginBottom: '8px' }}
+      >
+        <Button
+          upgrade
+          style={{ width: '100%', boxSizing: 'border-box' }}
+        >
+          PRIMARY
+        </Button>
+      </div>
+      <Button
+        upgrade
+        priority={PRIORITY.basicSecondary}
+        style={{ width: '100%', boxSizing: 'border-box' }}
+      >
+        SECONDARY
+      </Button>
+    </div>
+  </Dialog>
+);
+
+const DialogWithContent = props => (
   <Dialog isOpen {...props}>
     <div className="content" style={{ textAlign: 'center' }}>
       <Text typography={TYPOGRAPHY.largeTitle}>Are You Sure?</Text>
@@ -33,39 +69,45 @@ const DialogWithContent = (props) => (
   </Dialog>
 );
 
-const runDesktopSnapshots = (isRtl) => {
+const runDesktopSnapshots = isRtl => {
   story('Basic', () => {
-    snap(
-      `Desktop with default props  ${isRtl ? 'rtl' : ''}`,
-      TPAComponentsWrapper({ mobile: false, rtl: isRtl })(<Dialog isOpen />),
-    );
+    snap(`Desktop with default props  ${isRtl ? 'rtl' : ''}`, () => (
+      <VisualTestWrapper isRtl={isRtl} isMobile={false}>
+        <Dialog isOpen />
+      </VisualTestWrapper>
+    ));
     snap(
       `Desktop Dialog with some content  ${isRtl ? 'rtl' : ''}`,
-      TPAComponentsWrapper({ mobile: false, rtl: isRtl })(
-        <DialogWithContent />,
+      () => (
+        <VisualTestWrapper isRtl={isRtl} isMobile={false}>
+          <DialogWithContent />
+        </VisualTestWrapper>
       ),
     );
   });
 };
 
-const runMobileSnapshots = (isRtl) => {
+const runMobileSnapshots = isRtl => {
   story('Basic', () => {
-    snap(
-      `Mobile with default props  ${isRtl ? 'rtl' : ''}`,
-      TPAComponentsWrapper({ mobile: true, rtl: isRtl })(<DialogWithContent />),
-    );
+    snap(`Mobile with default props  ${isRtl ? 'rtl' : ''}`, () => (
+      <VisualTestWrapper isRtl={isRtl} isMobile>
+        <MobileDialogWithContent />
+      </VisualTestWrapper>
+    ));
     snap(
       `Mobile with not fullscreen version  ${isRtl ? 'rtl' : ''}`,
-      TPAComponentsWrapper({ mobile: true, rtl: isRtl })(
-        <DialogWithContent notFullscreenOnMobile />,
+      () => (
+        <VisualTestWrapper isRtl={isRtl} isMobile>
+          <MobileDialogWithContent notFullscreenOnMobile />
+        </VisualTestWrapper>
       ),
     );
   });
 };
 
 visualize('Dialog', () => {
-  [false, true].map((value) => runMobileSnapshots(value));
-  [false, true].map((value) => runDesktopSnapshots(value));
+  [false, true].map(value => runMobileSnapshots(value));
+  [false, true].map(value => runDesktopSnapshots(value));
 
   story('Wired to palette', () => {
     snap('Dialog with some content', () => {

--- a/src/components/Dialog/Dialog.visual.tsx
+++ b/src/components/Dialog/Dialog.visual.tsx
@@ -3,10 +3,11 @@ import { visualize, story, snap } from 'storybook-snapper';
 import { Dialog } from './';
 import { Text, TYPOGRAPHY } from '../Text';
 import { Button, PRIORITY } from '../Button';
+import { TPAComponentsWrapper } from '../../test/utils';
 // import { setDarkPalette } from '../../test/visualTestUtils';
 
 const DialogWithContent = (props) => (
-  <Dialog isOpen wiredToSiteColors={props.wired}>
+  <Dialog isOpen {...props}>
     <div className="content" style={{ textAlign: 'center' }}>
       <Text typography={TYPOGRAPHY.largeTitle}>Are You Sure?</Text>
       <div
@@ -32,15 +33,43 @@ const DialogWithContent = (props) => (
   </Dialog>
 );
 
-visualize('Dialog', () => {
-  story('simple', () => {
-    snap('default props', <Dialog isOpen />);
-    snap('Dialog with some content', <DialogWithContent />);
+const runDesktopSnapshots = (isRtl) => {
+  story('Basic', () => {
+    snap(
+      `Desktop with default props  ${isRtl ? 'rtl' : ''}`,
+      TPAComponentsWrapper({ mobile: false, rtl: isRtl })(<Dialog isOpen />),
+    );
+    snap(
+      `Desktop Dialog with some content  ${isRtl ? 'rtl' : ''}`,
+      TPAComponentsWrapper({ mobile: false, rtl: isRtl })(
+        <DialogWithContent />,
+      ),
+    );
   });
+};
+
+const runMobileSnapshots = (isRtl) => {
+  story('Basic', () => {
+    snap(
+      `Mobile with default props  ${isRtl ? 'rtl' : ''}`,
+      TPAComponentsWrapper({ mobile: true, rtl: isRtl })(<DialogWithContent />),
+    );
+    snap(
+      `Mobile with not fullscreen version  ${isRtl ? 'rtl' : ''}`,
+      TPAComponentsWrapper({ mobile: true, rtl: isRtl })(
+        <DialogWithContent notFullscreenOnMobile />,
+      ),
+    );
+  });
+};
+
+visualize('Dialog', () => {
+  [false, true].map((value) => runMobileSnapshots(value));
+  [false, true].map((value) => runDesktopSnapshots(value));
 
   story('Wired to palette', () => {
     snap('Dialog with some content', () => {
-      return <DialogWithContent wired />;
+      return <DialogWithContent wiredToSiteColors />;
     });
 
     // TODO uncomment when we'll support dark theme tests

--- a/src/components/Dialog/Dialog.visual.tsx
+++ b/src/components/Dialog/Dialog.visual.tsx
@@ -3,10 +3,10 @@ import { visualize, story, snap } from 'storybook-snapper';
 import { Dialog } from './';
 import { Text, TYPOGRAPHY } from '../Text';
 import { Button, PRIORITY } from '../Button';
-import { VisualTestWrapper } from '../../test/visualTestWrapper';
+import { AsyncVisualTestWrapper } from '../../test/visualTestWrapper';
 // import { setDarkPalette } from '../../test/visualTestUtils';
 
-const MobileDialogWithContent = props => (
+const MobileDialogWithContent = (props) => (
   <Dialog isOpen {...props}>
     <div className="content" style={{ textAlign: 'center' }}>
       <Text typography={TYPOGRAPHY.largeTitle} tagName="div">
@@ -20,14 +20,8 @@ const MobileDialogWithContent = props => (
           Are You Sure you want to discard the changes you made?
         </Text>
       </div>
-      <div
-        className="primary-btn-container"
-        style={{ marginBottom: '8px' }}
-      >
-        <Button
-          upgrade
-          style={{ width: '100%', boxSizing: 'border-box' }}
-        >
+      <div className="primary-btn-container" style={{ marginBottom: '8px' }}>
+        <Button upgrade style={{ width: '100%', boxSizing: 'border-box' }}>
           PRIMARY
         </Button>
       </div>
@@ -42,7 +36,7 @@ const MobileDialogWithContent = props => (
   </Dialog>
 );
 
-const DialogWithContent = props => (
+const DialogWithContent = (props) => (
   <Dialog isOpen {...props}>
     <div className="content" style={{ textAlign: 'center' }}>
       <Text typography={TYPOGRAPHY.largeTitle}>Are You Sure?</Text>
@@ -69,45 +63,53 @@ const DialogWithContent = props => (
   </Dialog>
 );
 
-const runDesktopSnapshots = isRtl => {
+const runDesktopSnapshots = (isRtl) => {
   story('Basic', () => {
-    snap(`Desktop with default props  ${isRtl ? 'rtl' : ''}`, () => (
-      <VisualTestWrapper isRtl={isRtl} isMobile={false}>
+    snap(`Desktop with default props  ${isRtl ? 'rtl' : ''}`, (doSnap) => (
+      <AsyncVisualTestWrapper
+        isRtl={isRtl}
+        isMobile={false}
+        onDoneCallback={doSnap}
+      >
         <Dialog isOpen />
-      </VisualTestWrapper>
+      </AsyncVisualTestWrapper>
     ));
     snap(
       `Desktop Dialog with some content  ${isRtl ? 'rtl' : ''}`,
-      () => (
-        <VisualTestWrapper isRtl={isRtl} isMobile={false}>
+      (doSnap) => (
+        <AsyncVisualTestWrapper
+          isRtl={isRtl}
+          isMobile={false}
+          onDoneCallback={doSnap}
+        >
           <DialogWithContent />
-        </VisualTestWrapper>
+        </AsyncVisualTestWrapper>
       ),
     );
   });
 };
 
-const runMobileSnapshots = isRtl => {
+const runMobileSnapshots = (isRtl) => {
   story('Basic', () => {
-    snap(`Mobile with default props  ${isRtl ? 'rtl' : ''}`, () => (
-      <VisualTestWrapper isRtl={isRtl} isMobile>
+    snap(`Mobile with default props  ${isRtl ? 'rtl' : ''}`, (doSnap) => (
+      <AsyncVisualTestWrapper isRtl={isRtl} isMobile onDoneCallback={doSnap}>
         <MobileDialogWithContent />
-      </VisualTestWrapper>
+      </AsyncVisualTestWrapper>
     ));
     snap(
       `Mobile with not fullscreen version  ${isRtl ? 'rtl' : ''}`,
-      () => (
-        <VisualTestWrapper isRtl={isRtl} isMobile>
+      (doSnap) => (
+        <AsyncVisualTestWrapper isRtl={isRtl} isMobile onDoneCallback={doSnap}>
           <MobileDialogWithContent notFullscreenOnMobile />
-        </VisualTestWrapper>
+        </AsyncVisualTestWrapper>
       ),
     );
   });
 };
 
 visualize('Dialog', () => {
-  [false, true].map(value => runMobileSnapshots(value));
-  [false, true].map(value => runDesktopSnapshots(value));
+  [false, true].map((value) => runMobileSnapshots(value));
+  [false, true].map((value) => runDesktopSnapshots(value));
 
   story('Wired to palette', () => {
     snap('Dialog with some content', () => {

--- a/src/components/Dialog/docs/examples.ts
+++ b/src/components/Dialog/docs/examples.ts
@@ -12,9 +12,9 @@ class ModalExample extends React.Component {
 
   render() {
     const { isDialogOpen } = this.state;
-    
+
     return (
-      ${content} 
+      ${content}
     );
   }
 }
@@ -51,6 +51,31 @@ export const mobileExample = buildExample(`
     <MobileExample>
       <Button upgrade onClick={this.onOpenDialogButtonClick}>Open Dialog</Button>
       <Dialog isOpen={isDialogOpen} onClose={this.onCloseDialog} >
+        <div className="content" style={{ textAlign: 'center' }}>
+            <Text typography="MobileSmallTitleFont" tagName="div">Discard draft?</Text>
+            <div className="text-container" style={{ marginTop: '16px', marginBottom: '32px' }}>
+                <Text typography="MobileRunningTextFont" tagName="div">Are You Sure you want to discard the changes you made?</Text>
+            </div>
+            <div className="primary-btn-container" style={{marginBottom: '8px'}}>
+                  <Button upgrade>
+                    PRIMARY
+                  </Button>
+            </div>
+            <Button
+              upgrade
+              priority={PRIORITY.basicSecondary}
+            >
+              SECONDARY
+            </Button>
+        </div>
+      </Dialog>
+     </MobileExample>
+`);
+
+export const mobileExampleNotFullscreen = buildExample(`
+    <MobileExample>
+      <Button upgrade onClick={this.onOpenDialogButtonClick}>Open Dialog</Button>
+      <Dialog isOpen={isDialogOpen} onClose={this.onCloseDialog} notFullscreenOnMobile>
         <div className="content" style={{ textAlign: 'center' }}>
             <Text typography="MobileSmallTitleFont" tagName="div">Discard draft?</Text>
             <div className="text-container" style={{ marginTop: '16px', marginBottom: '32px' }}>

--- a/src/components/Dialog/docs/examples.ts
+++ b/src/components/Dialog/docs/examples.ts
@@ -64,6 +64,7 @@ export const mobileExample = buildExample(`
             <Button
               upgrade
               priority={PRIORITY.basicSecondary}
+              style={{ width: '100%', boxSizing: 'border-box' }}
             >
               SECONDARY
             </Button>

--- a/src/components/Dialog/docs/examples.ts
+++ b/src/components/Dialog/docs/examples.ts
@@ -82,7 +82,7 @@ export const mobileExampleNotFullscreen = buildExample(`
                 <Text typography="runningText" tagName="div">Are You Sure you want to discard the changes you made?</Text>
             </div>
             <div className="primary-btn-container" style={{marginBottom: '8px'}}>
-                  <Button upgrade>
+                  <Button upgrade style={{ width: '100%', boxSizing: 'border-box' }}>
                     PRIMARY
                   </Button>
             </div>

--- a/src/components/Dialog/docs/examples.ts
+++ b/src/components/Dialog/docs/examples.ts
@@ -52,12 +52,12 @@ export const mobileExample = buildExample(`
       <Button upgrade onClick={this.onOpenDialogButtonClick}>Open Dialog</Button>
       <Dialog isOpen={isDialogOpen} onClose={this.onCloseDialog} >
         <div className="content" style={{ textAlign: 'center' }}>
-            <Text typography="MobileSmallTitleFont" tagName="div">Discard draft?</Text>
+            <Text typography="largeTitle" tagName="div">Discard draft?</Text>
             <div className="text-container" style={{ marginTop: '16px', marginBottom: '32px' }}>
-                <Text typography="MobileRunningTextFont" tagName="div">Are You Sure you want to discard the changes you made?</Text>
+                <Text typography="runningText" tagName="div">Are You Sure you want to discard the changes you made?</Text>
             </div>
             <div className="primary-btn-container" style={{marginBottom: '8px'}}>
-                  <Button upgrade>
+                  <Button upgrade style={{ width: '100%', boxSizing: 'border-box' }}>
                     PRIMARY
                   </Button>
             </div>

--- a/src/components/Dialog/docs/examples.ts
+++ b/src/components/Dialog/docs/examples.ts
@@ -89,6 +89,7 @@ export const mobileExampleNotFullscreen = buildExample(`
             <Button
               upgrade
               priority={PRIORITY.basicSecondary}
+               style={{ width: '100%', boxSizing: 'border-box' }}
             >
               SECONDARY
             </Button>

--- a/src/components/Dialog/docs/examples.ts
+++ b/src/components/Dialog/docs/examples.ts
@@ -77,7 +77,7 @@ export const mobileExampleNotFullscreen = buildExample(`
       <Button upgrade onClick={this.onOpenDialogButtonClick}>Open Dialog</Button>
       <Dialog isOpen={isDialogOpen} onClose={this.onCloseDialog} notFullscreenOnMobile>
         <div className="content" style={{ textAlign: 'center' }}>
-            <Text typography="MobileSmallTitleFont" tagName="div">Discard draft?</Text>
+            <Text typography="largeTitle" tagName="div">Discard draft?</Text>
             <div className="text-container" style={{ marginTop: '16px', marginBottom: '32px' }}>
                 <Text typography="runningText" tagName="div">Are You Sure you want to discard the changes you made?</Text>
             </div>

--- a/src/components/Dialog/docs/examples.ts
+++ b/src/components/Dialog/docs/examples.ts
@@ -79,7 +79,7 @@ export const mobileExampleNotFullscreen = buildExample(`
         <div className="content" style={{ textAlign: 'center' }}>
             <Text typography="MobileSmallTitleFont" tagName="div">Discard draft?</Text>
             <div className="text-container" style={{ marginTop: '16px', marginBottom: '32px' }}>
-                <Text typography="MobileRunningTextFont" tagName="div">Are You Sure you want to discard the changes you made?</Text>
+                <Text typography="runningText" tagName="div">Are You Sure you want to discard the changes you made?</Text>
             </div>
             <div className="primary-btn-container" style={{marginBottom: '8px'}}>
                   <Button upgrade>

--- a/src/components/Dialog/docs/index.story.tsx
+++ b/src/components/Dialog/docs/index.story.tsx
@@ -108,7 +108,14 @@ export default {
 
           ...[
             { title: 'Example', source: examples.example },
-            { title: 'Mobile Example', source: examples.mobileExample },
+            {
+              title: 'Mobile Example',
+              source: examples.mobileExample,
+            },
+            {
+              title: 'Mobile Example with non-fullscreen Dialog',
+              source: examples.mobileExampleNotFullscreen,
+            },
           ].map(code),
         ],
       }),

--- a/src/test/visualTestWrapper.tsx
+++ b/src/test/visualTestWrapper.tsx
@@ -2,21 +2,42 @@ import * as React from 'react';
 import { TPAComponentsProvider } from '../components/TPAComponentsConfig';
 import { MobileExample } from '../../stories/utils/MobileExample';
 
-export const VisualTestWrapper: React.FC<{
-  isMobile?: boolean;
-  isRtl?: boolean;
-}> = ({ isMobile, isRtl, children }) => {
-  return (
-    <>
-      {isMobile ? (
-        <MobileExample isRtl={isRtl}>
-          <div dir={isRtl ? 'rtl' : 'ltr'}>{children}</div>
-        </MobileExample>
-      ) : (
-        <TPAComponentsProvider value={{ mobile: false, rtl: isRtl }}>
-          <div dir={isRtl ? 'rtl' : 'ltr'}>{children}</div>
-        </TPAComponentsProvider>
-      )}
-    </>
-  );
-};
+export class AsyncVisualTestWrapper extends React.Component<{
+  isMobile: boolean;
+  isRtl: boolean;
+  onDoneCallback(): void;
+  onDoneTimeout?: number;
+}> {
+  static defaultProps = {
+    onMountTimeout: 1000,
+  };
+
+  onDone = () =>
+    setTimeout(
+      () => this.props.onDoneCallback(),
+      this.props.onDoneTimeout,
+    );
+
+  componentDidMount() {
+    !this.props.isMobile && this.onDone();
+  }
+
+  render() {
+    const { isMobile, isRtl, children } = this.props;
+    return (
+      <>
+        {isMobile ? (
+          <MobileExample isRtl={isRtl} onMobileReady={this.onDone}>
+            <div dir={isRtl ? 'rtl' : 'ltr'}>{children}</div>
+          </MobileExample>
+        ) : (
+          <TPAComponentsProvider
+            value={{ mobile: false, rtl: isRtl }}
+          >
+            <div dir={isRtl ? 'rtl' : 'ltr'}>{children}</div>
+          </TPAComponentsProvider>
+        )}
+      </>
+    );
+  }
+}

--- a/src/test/visualTestWrapper.tsx
+++ b/src/test/visualTestWrapper.tsx
@@ -2,21 +2,13 @@ import * as React from 'react';
 import { TPAComponentsProvider } from '../components/TPAComponentsConfig';
 import { MobileExample } from '../../stories/utils/MobileExample';
 
+const TIMEOUT_DEFAULT = 2000;
 export class AsyncVisualTestWrapper extends React.Component<{
   isMobile: boolean;
   isRtl: boolean;
   onDoneCallback(): void;
-  onDoneTimeout?: number;
 }> {
-  static defaultProps = {
-    onMountTimeout: 1000,
-  };
-
-  onDone = () =>
-    setTimeout(
-      () => this.props.onDoneCallback(),
-      this.props.onDoneTimeout,
-    );
+  onDone = () => setTimeout(() => this.props.onDoneCallback(), TIMEOUT_DEFAULT);
 
   componentDidMount() {
     !this.props.isMobile && this.onDone();
@@ -31,9 +23,7 @@ export class AsyncVisualTestWrapper extends React.Component<{
             <div dir={isRtl ? 'rtl' : 'ltr'}>{children}</div>
           </MobileExample>
         ) : (
-          <TPAComponentsProvider
-            value={{ mobile: false, rtl: isRtl }}
-          >
+          <TPAComponentsProvider value={{ mobile: false, rtl: isRtl }}>
             <div dir={isRtl ? 'rtl' : 'ltr'}>{children}</div>
           </TPAComponentsProvider>
         )}

--- a/src/test/visualTestWrapper.tsx
+++ b/src/test/visualTestWrapper.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { TPAComponentsProvider } from '../components/TPAComponentsConfig';
+import { MobileExample } from '../../stories/utils/MobileExample';
+
+export const VisualTestWrapper: React.FC<{
+  isMobile?: boolean;
+  isRtl?: boolean;
+}> = ({ isMobile, isRtl, children }) => {
+  return (
+    <>
+      {isMobile ? (
+        <MobileExample isRtl={isRtl}>
+          <div dir={isRtl ? 'rtl' : 'ltr'}>{children}</div>
+        </MobileExample>
+      ) : (
+        <TPAComponentsProvider value={{ mobile: false, rtl: isRtl }}>
+          <div dir={isRtl ? 'rtl' : 'ltr'}>{children}</div>
+        </TPAComponentsProvider>
+      )}
+    </>
+  );
+};

--- a/stories/utils/MobileExample.st.css
+++ b/stories/utils/MobileExample.st.css
@@ -1,25 +1,25 @@
 .root {
-    width: 300px;
-    height: 640px;
-    position: relative;
+  width: 349px;
+  height: 600px;
+  position: relative;
 }
 
 .frame {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: auto;
-    z-index: 1;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: auto;
+  z-index: 1;
 }
 
 .root iframe {
-    position: absolute;
-    top: 45px;
-    left: 13px;
-    z-index: 2;
-    width: 273px;
-    height: 548px;
-    background-color: white;
-    border-radius: 11px;
+  position: absolute;
+  top: 52px;
+  left: 14px;
+  z-index: 2;
+  width: 320px;
+  height: 512px;
+  background-color: white;
+  border-radius: 11px;
 }

--- a/stories/utils/MobileExample.tsx
+++ b/stories/utils/MobileExample.tsx
@@ -6,6 +6,7 @@ import { st, classes } from './MobileExample.st.css';
 
 export class MobileExample extends React.Component<{
   isRtl?: boolean;
+  onMobileReady?: () => void;
 }> {
   static defaultProps = {
     isRtl: false,
@@ -18,7 +19,7 @@ export class MobileExample extends React.Component<{
       this._frameBody = this._frameRef.current.contentDocument.getElementById(
         'mobile-root',
       );
-      this.forceUpdate();
+      this.forceUpdate(this.props.onMobileReady);
     }
   };
 
@@ -41,7 +42,10 @@ export class MobileExample extends React.Component<{
           onLoad={this._onIframeLoad}
         >
           {this._frameBody &&
-            ReactDOM.createPortal(this._getContent(), this._frameBody)}
+            ReactDOM.createPortal(
+              this._getContent(),
+              this._frameBody,
+            )}
         </iframe>
         <PixelFrame className={classes.frame} />
       </div>

--- a/stories/utils/MobileExample.tsx
+++ b/stories/utils/MobileExample.tsx
@@ -6,7 +6,7 @@ import { st, classes } from './MobileExample.st.css';
 
 export class MobileExample extends React.Component<{
   isRtl?: boolean;
-  onMobileReady?: () => void;
+  onMobileReady?(): void;
 }> {
   static defaultProps = {
     isRtl: false,
@@ -42,10 +42,7 @@ export class MobileExample extends React.Component<{
           onLoad={this._onIframeLoad}
         >
           {this._frameBody &&
-            ReactDOM.createPortal(
-              this._getContent(),
-              this._frameBody,
-            )}
+            ReactDOM.createPortal(this._getContent(), this._frameBody)}
         </iframe>
         <PixelFrame className={classes.frame} />
       </div>

--- a/stories/utils/MobileExample.tsx
+++ b/stories/utils/MobileExample.tsx
@@ -4,7 +4,12 @@ import { PixelFrame } from './PixelFrame';
 import { TPAComponentsProvider } from '../../src/components/TPAComponentsConfig';
 import { st, classes } from './MobileExample.st.css';
 
-export class MobileExample extends React.Component {
+export class MobileExample extends React.Component<{
+  isRtl?: boolean;
+}> {
+  static defaultProps = {
+    isRtl: false,
+  };
   private readonly _frameRef = React.createRef<HTMLIFrameElement>();
   private _frameBody: HTMLElement;
 
@@ -18,9 +23,9 @@ export class MobileExample extends React.Component {
   };
 
   _getContent() {
-    const { children } = this.props;
+    const { children, isRtl } = this.props;
     return (
-      <TPAComponentsProvider value={{ mobile: true }}>
+      <TPAComponentsProvider value={{ mobile: true, rtl: isRtl }}>
         {children}
       </TPAComponentsProvider>
     );

--- a/stories/utils/PixelFrame.tsx
+++ b/stories/utils/PixelFrame.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 
-export class PixelFrame extends React.Component<{ className: string }> {
+export class PixelFrame extends React.Component<{
+  className: string;
+}> {
   render() {
     const { className } = this.props;
     return (
@@ -28,7 +30,7 @@ export class PixelFrame extends React.Component<{ className: string }> {
             fillRule="evenodd"
             rx="80"
             ry="80"
-            height="1456"
+            height="1216"
             width="682"
             y="-403.64"
             x="0"
@@ -39,7 +41,7 @@ export class PixelFrame extends React.Component<{ className: string }> {
               fillOpacity=".86667"
               rx="25"
               ry="25"
-              height="1250"
+              height="900"
               width="625"
               y="-300.64"
               x="28.5"
@@ -50,7 +52,7 @@ export class PixelFrame extends React.Component<{ className: string }> {
               ry="5"
               height="18"
               width="160"
-              y="992.36"
+              y="752.36"
               x="261"
             />
             <rect


### PR DESCRIPTION
<!--
  Thanks for creating a pull request to `wix-ui-tpa`!

  =========================
   Before creating the PR:
  =========================
  
    - Please make sure your commits are signed,the PR cannot be merged without it.
      Read more about it here:
      https://github.com/wix/wix-style-react/blob/master/docs/contribution/CREATE_PR.md#sign-commits
      
    - If the PR changes/adds something to the UI, make sure it's aligned to the design system specs:
      https://zeroheight.com/7sjjzhgo2/p/7181b5-tpa-design-system
      
  -->

# ✨ Pull Request

### 💁 Description

	Added ability to have non-fullscreen modals on mobile
	https://jira.wixpress.com/plugins/servlet/samlsso?redirectTo=%2Fbrowse%2FDSM-1449

...

### 💭 Motivation

Non-fullscreen modal on mobile has vertical constraints -> max height of 440px and minimum top/bottom padding should be 20px. This vertical padding would be needed in edge-cases where screen height would be smaller than possible Dialog component max-height. So to always have vertical padding, added the outer wrapper container for Dialog content.

...


### ☝️ TODOs <!-- optional -->

<!---
  List leftover tasks, related PR's blocking this etc...
  e.g
  "- [ ] waiting for PR merge in wix-ui-core"
  ...
  -->
...

### 👀  PR is ready for review 

<!-- mark checkbox to let reviewers know you're ready -->

- [x] Ready for review
