### PR TITLE
<ActionsMenuLayout /> - fix focus handling

### DIFF
--- a/perfer.config.js
+++ b/perfer.config.js
@@ -1,7 +1,7 @@
 const files = [
   ['ActionsMenuLayout.bundle.min.js', 6],
-  ['ActionsMenuLayoutPerfBasic.bundle.min.js', 6],
-  ['ActionsMenuLayoutPerfExtended.bundle.min.js', 6.5],
+  ['ActionsMenuLayoutPerfBasic.bundle.min.js', 6.5],
+  ['ActionsMenuLayoutPerfExtended.bundle.min.js', 7],
   ['AddItem.bundle.min.js', 45.5],
   ['Autocomplete.bundle.min.js', 37],
   ['Avatar.bundle.min.js', 16.1],

--- a/src/components/ActionsMenuLayout/ActionsMenuLayout.driver.ts
+++ b/src/components/ActionsMenuLayout/ActionsMenuLayout.driver.ts
@@ -13,6 +13,7 @@ export interface ActionsMenuLayoutDriver extends BaseUniDriver {
   clickItem(content): Promise<any>;
   item(content): UniDriver<HTMLLIElement>;
   layout(): UniDriver<HTMLUListElement>;
+  isItemFocused(content): Promise<boolean>;
 }
 
 function actionsMenuLayoutItem(base: UniDriver, content) {
@@ -30,6 +31,9 @@ export const actionsMenuLayoutDriverFactory = (
       (await base.attr(ACTIONS_MENU_DATA_KEYS.mobile)) === 'true',
     item: (content) => actionsMenuLayoutItem(base, content),
     clickItem: (content) => actionsMenuLayoutItem(base, content).click(),
+    isItemFocused: async (content) =>
+      (await actionsMenuLayoutItem(base, content).getNative()) ===
+      document.activeElement,
     layout: () => base,
   };
 };

--- a/src/components/ActionsMenuLayout/ActionsMenuLayout.driver.ts
+++ b/src/components/ActionsMenuLayout/ActionsMenuLayout.driver.ts
@@ -13,7 +13,6 @@ export interface ActionsMenuLayoutDriver extends BaseUniDriver {
   clickItem(content): Promise<any>;
   item(content): UniDriver<HTMLLIElement>;
   layout(): UniDriver<HTMLUListElement>;
-  isItemFocused(content): Promise<boolean>;
 }
 
 function actionsMenuLayoutItem(base: UniDriver, content) {
@@ -31,9 +30,6 @@ export const actionsMenuLayoutDriverFactory = (
       (await base.attr(ACTIONS_MENU_DATA_KEYS.mobile)) === 'true',
     item: (content) => actionsMenuLayoutItem(base, content),
     clickItem: (content) => actionsMenuLayoutItem(base, content).click(),
-    isItemFocused: async (content) =>
-      (await actionsMenuLayoutItem(base, content).getNative()) ===
-      document.activeElement,
     layout: () => base,
   };
 };

--- a/src/components/ActionsMenuLayout/ActionsMenuLayout.e2e.ts
+++ b/src/components/ActionsMenuLayout/ActionsMenuLayout.e2e.ts
@@ -1,0 +1,56 @@
+import * as eyes from 'eyes.it';
+import { browser, Key } from 'protractor';
+import {
+  createStoryUrl,
+  waitForVisibilityOf,
+} from 'wix-ui-test-utils/protractor';
+import { StoryCategory } from '../../../stories/storyHierarchy';
+import { actionsMenuLayoutTestkitFactory } from '../../testkit/protractor';
+import { ActionsMenuLayoutDriver } from './ActionsMenuLayout.driver';
+import { ACTIONS_MENU_E2E_DATA_HOOK } from './dataHooks';
+
+describe('ActionsMenuLayout', () => {
+  const storyUrl = createStoryUrl({
+    kind: StoryCategory.TESTS,
+    story: 'ActionsMenuLayout',
+    withExamples: true,
+  });
+  let driver: ActionsMenuLayoutDriver;
+
+  beforeEach(async () => {
+    browser.get(storyUrl);
+    driver = actionsMenuLayoutTestkitFactory({
+      dataHook: ACTIONS_MENU_E2E_DATA_HOOK,
+    });
+
+    await waitForVisibilityOf(await driver.element(), 'Cannot find element');
+  });
+
+  eyes.it('should focus on second item on initial load', async () => {
+    await browser.sleep(200);
+  });
+
+  eyes.it('should focus first item in list after tab focus', async () => {
+    await browser.actions().sendKeys(Key.TAB).perform();
+    await browser.actions().sendKeys(Key.TAB).perform();
+    await browser.sleep(200);
+  });
+
+  eyes.it('should focus second item after using arrows', async () => {
+    await browser.actions().sendKeys(Key.ARROW_DOWN).perform();
+    await browser.sleep(200);
+  });
+
+  eyes.it('should focus on the last after clicking', async () => {
+    await driver.clickItem('item 5');
+    await browser.sleep(200);
+  });
+
+  eyes.it('should focus two items up after keyboard events', async () => {
+    //move mouse away so last item is not hovered
+    await browser.actions().mouseMove({ x: 0, y: 500 }).perform();
+    await browser.actions().sendKeys(Key.ARROW_UP).perform();
+    await browser.actions().sendKeys(Key.ARROW_UP).perform();
+    await browser.sleep(200);
+  });
+});

--- a/src/components/ActionsMenuLayout/ActionsMenuLayout.e2e.ts
+++ b/src/components/ActionsMenuLayout/ActionsMenuLayout.e2e.ts
@@ -40,17 +40,4 @@ describe('ActionsMenuLayout', () => {
     await browser.actions().sendKeys(Key.ARROW_DOWN).perform();
     await browser.sleep(200);
   });
-
-  eyes.it('should focus on the last after clicking', async () => {
-    await driver.clickItem('item 5');
-    await browser.sleep(200);
-  });
-
-  eyes.it('should focus two items up after keyboard events', async () => {
-    //move mouse away so last item is not hovered
-    await browser.actions().mouseMove({ x: 0, y: 500 }).perform();
-    await browser.actions().sendKeys(Key.ARROW_UP).perform();
-    await browser.actions().sendKeys(Key.ARROW_UP).perform();
-    await browser.sleep(200);
-  });
 });

--- a/src/components/ActionsMenuLayout/ActionsMenuLayout.spec.tsx
+++ b/src/components/ActionsMenuLayout/ActionsMenuLayout.spec.tsx
@@ -34,15 +34,14 @@ describe('ActionsMenuLayout', () => {
     expect(onClick).toHaveBeenCalled();
   });
 
-  it('should focus first element if focusedIndex undefined', async function () {
+  it('should not focus first element if focusedIndex is not provided', async function () {
     const driver = createDriver(
       <ActionsMenuLayout>
         <ActionsMenuLayout.Item onClick={() => {}} content="test" />
       </ActionsMenuLayout>,
     );
 
-    const item = await driver.item('test').getNative();
-    expect(document.activeElement).toEqual(item);
+    expect(await driver.isItemFocused('test')).toEqual(false);
   });
 
   it('should focus 2nd element if focusedIndex=1', async function () {
@@ -53,39 +52,31 @@ describe('ActionsMenuLayout', () => {
       </ActionsMenuLayout>,
     );
 
-    const item = await driver.item('test2').getNative();
-    expect(document.activeElement).toEqual(item);
+    expect(await driver.isItemFocused('test2')).toEqual(true);
   });
 
   it('should navigate by keyboard keys', async function () {
     const driver = createDriver(
-      <ActionsMenuLayout>
+      <ActionsMenuLayout focusedIndex={1}>
         <ActionsMenuLayout.Item onClick={() => {}} content="test1" />
         <ActionsMenuLayout.Item onClick={() => {}} content="test2" />
         <ActionsMenuLayout.Item onClick={() => {}} content="test3" />
       </ActionsMenuLayout>,
     );
 
-    const item1 = await driver.item('test1').getNative();
-    const item2 = await driver.item('test2').getNative();
-    const item3 = await driver.item('test3').getNative();
     const layout = driver.layout();
 
-    expect(document.activeElement).toEqual(item1);
+    expect(await driver.isItemFocused('test2')).toEqual(true);
 
     await layout.pressKey(KEYS.ArrowDown);
 
-    expect(document.activeElement).toEqual(item2);
-
+    expect(await driver.isItemFocused('test3')).toEqual(true);
     await layout.pressKey(KEYS.ArrowDown);
 
-    expect(document.activeElement).toEqual(item3);
-
-    await layout.pressKey(KEYS.ArrowDown);
-    expect(document.activeElement).toEqual(item1);
+    expect(await driver.isItemFocused('test1')).toEqual(true);
 
     await layout.pressKey(KEYS.ArrowUp);
-    expect(document.activeElement).toEqual(item3);
+    expect(await driver.isItemFocused('test3')).toEqual(true);
   });
 
   it('should fire onClick on space and enter keys', async function () {

--- a/src/components/ActionsMenuLayout/ActionsMenuLayout.spec.tsx
+++ b/src/components/ActionsMenuLayout/ActionsMenuLayout.spec.tsx
@@ -22,6 +22,30 @@ describe('ActionsMenuLayout', () => {
     expect(await driver.exists()).toBe(true);
   });
 
+  it('should not focus first element if focusedIndex is not provided', async function () {
+    const driver = createDriver(
+      <ActionsMenuLayout>
+        <ActionsMenuLayout.Item onClick={() => {}} content="test" />
+      </ActionsMenuLayout>,
+    );
+
+    const item = await driver.item('test').getNative();
+    expect(document.activeElement).not.toEqual(item);
+  });
+
+  it('should focus 2nd element if focusedIndex=1', async function () {
+    const driver = createDriver(
+      <ActionsMenuLayout focusedIndex={1}>
+        <ActionsMenuLayout.Item onClick={() => {}} content="test1" />
+        <ActionsMenuLayout.Item onClick={() => {}} content="test2" />
+      </ActionsMenuLayout>,
+    );
+
+    const item = await driver.item('test2').getNative();
+
+    expect(document.activeElement).toEqual(item);
+  });
+
   it('should trigger onClick', async function () {
     const onClick = jest.fn();
     const driver = createDriver(
@@ -34,27 +58,6 @@ describe('ActionsMenuLayout', () => {
     expect(onClick).toHaveBeenCalled();
   });
 
-  it('should not focus first element if focusedIndex is not provided', async function () {
-    const driver = createDriver(
-      <ActionsMenuLayout>
-        <ActionsMenuLayout.Item onClick={() => {}} content="test" />
-      </ActionsMenuLayout>,
-    );
-
-    expect(await driver.isItemFocused('test')).toEqual(false);
-  });
-
-  it('should focus 2nd element if focusedIndex=1', async function () {
-    const driver = createDriver(
-      <ActionsMenuLayout focusedIndex={1}>
-        <ActionsMenuLayout.Item onClick={() => {}} content="test1" />
-        <ActionsMenuLayout.Item onClick={() => {}} content="test2" />
-      </ActionsMenuLayout>,
-    );
-
-    expect(await driver.isItemFocused('test2')).toEqual(true);
-  });
-
   it('should navigate by keyboard keys', async function () {
     const driver = createDriver(
       <ActionsMenuLayout focusedIndex={1}>
@@ -65,18 +68,21 @@ describe('ActionsMenuLayout', () => {
     );
 
     const layout = driver.layout();
+    const item1 = await driver.item('test1').getNative();
+    const item2 = await driver.item('test2').getNative();
+    const item3 = await driver.item('test3').getNative();
 
-    expect(await driver.isItemFocused('test2')).toEqual(true);
+    expect(document.activeElement).toEqual(item2);
 
     await layout.pressKey(KEYS.ArrowDown);
 
-    expect(await driver.isItemFocused('test3')).toEqual(true);
+    expect(document.activeElement).toEqual(item3);
     await layout.pressKey(KEYS.ArrowDown);
 
-    expect(await driver.isItemFocused('test1')).toEqual(true);
+    expect(document.activeElement).toEqual(item1);
 
     await layout.pressKey(KEYS.ArrowUp);
-    expect(await driver.isItemFocused('test3')).toEqual(true);
+    expect(document.activeElement).toEqual(item3);
   });
 
   it('should fire onClick on space and enter keys', async function () {

--- a/src/components/ActionsMenuLayout/ActionsMenuLayout.tsx
+++ b/src/components/ActionsMenuLayout/ActionsMenuLayout.tsx
@@ -9,6 +9,10 @@ import { KEYS } from '../../common/keyCodes';
 
 export interface ActionsMenuLayoutProps extends TPAComponentProps {
   alignment?: Alignment;
+  /**
+   * Provide item index which will be focused on initial render.
+   * If prop is not provided, no item will be autofocused
+   */
   focusedIndex?: number;
   /** a11y */
   'aria-labeledby'?: string;
@@ -23,7 +27,7 @@ export class ActionsMenuLayout extends React.Component<ActionsMenuLayoutProps> {
   static displayName = 'ActionsMenuLayout';
 
   state = {
-    focusedIdx: 0,
+    focusedIdx: this.props.focusedIndex ?? 0,
   };
 
   liRefs: {
@@ -34,11 +38,8 @@ export class ActionsMenuLayout extends React.Component<ActionsMenuLayoutProps> {
 
   componentDidMount() {
     const { focusedIndex } = this.props;
-
     if (focusedIndex) {
       this._focusItem(focusedIndex);
-    } else {
-      this._focusItem(this.state.focusedIdx);
     }
   }
 
@@ -87,20 +88,21 @@ export class ActionsMenuLayout extends React.Component<ActionsMenuLayoutProps> {
     }
   };
 
-  _onFocus = () => {
-    const { focusedIdx } = this.state;
-    const { focusedIndex } = this.props;
-
-    this._focusItem(
-      typeof focusedIndex !== 'undefined' ? focusedIndex : focusedIdx,
+  _onFocus = (e) => {
+    const focusOnChild = !!Object.values(this.liRefs).find(
+      (i) => i.liRef?.current === e.target,
     );
+    //reset focus on first item
+    if (!focusOnChild) {
+      this._focusItem(0);
+    }
   };
 
   // to get proper index on mouse click
   _onClick = (e) => {
-    const indexValue = Object.values(this.liRefs).findIndex((i) => {
-      return i.liRef?.current === e.target;
-    });
+    const indexValue = Object.values(this.liRefs).findIndex(
+      (i) => i.liRef?.current === e.target,
+    );
 
     if (indexValue >= 0) {
       this._focusItem(indexValue);
@@ -122,7 +124,7 @@ export class ActionsMenuLayout extends React.Component<ActionsMenuLayoutProps> {
             role="menu"
             aria-labelledby={this.props['aria-labeledby']}
             aria-label={this.props['aria-label']}
-            tabIndex={-1}
+            tabIndex={0}
           >
             {React.Children.map(children, (child: React.ReactElement, index) =>
               child.type === ActionsMenuLayoutItem

--- a/src/components/ActionsMenuLayout/ActionsMenuLayout.tsx
+++ b/src/components/ActionsMenuLayout/ActionsMenuLayout.tsx
@@ -42,11 +42,6 @@ export class ActionsMenuLayout extends React.Component<ActionsMenuLayoutProps> {
     if (focusedIndex) {
       this._focusItem(focusedIndex);
     }
-    this._attachRefListeners(this.liRefs);
-  }
-
-  componentwillUnmount() {
-    this._removeRefListeners(this.liRefs);
   }
 
   getDataAttributes(mobile: boolean) {
@@ -54,24 +49,6 @@ export class ActionsMenuLayout extends React.Component<ActionsMenuLayoutProps> {
       [ACTIONS_MENU_DATA_KEYS.mobile]: mobile,
     };
   }
-
-  _attachRefListeners = (refs: LiRefs) => {
-    const refArr = Object.values(refs);
-
-    if (refArr.length) {
-      refArr.map(({ liRef }) =>
-        liRef.current.addEventListener('click', this._onListItemClick),
-      );
-    }
-  };
-  _removeRefListeners = (refs: LiRefs) => {
-    const refArr = Object.values(refs);
-    if (refArr.length) {
-      refArr.map(({ liRef }) =>
-        liRef.current.removeEventListener('click', this._onListItemClick),
-      );
-    }
-  };
 
   _getNextItemIdx(direction: 1 | -1): number {
     const nextItem = this.state.focusedIdx + direction;
@@ -99,16 +76,6 @@ export class ActionsMenuLayout extends React.Component<ActionsMenuLayoutProps> {
       },
     );
   }
-
-  _onListItemClick = (e: MouseEvent) => {
-    const indexValue = Object.values(this.liRefs).findIndex(
-      (i) => i.liRef?.current === e.currentTarget,
-    );
-
-    if (indexValue >= 0) {
-      this._focusItem(indexValue);
-    }
-  };
 
   _onKeyDown = (e: React.KeyboardEvent<HTMLUListElement>) => {
     if (e.key === KEYS.ArrowDown || e.key === KEYS.ArrowDownIE) {

--- a/src/components/ActionsMenuLayout/ActionsMenuLayout.visual.tsx
+++ b/src/components/ActionsMenuLayout/ActionsMenuLayout.visual.tsx
@@ -84,6 +84,12 @@ function testSuite(alignment) {
         </ActionsMenuLayout>
       </TPAComponentsProvider>
     ));
+
+    snap('should have focus on second item', () => (
+      <ActionsMenuLayout alignment={alignment} focusedIndex={1}>
+        {generateItems()}
+      </ActionsMenuLayout>
+    ));
   });
 }
 

--- a/src/components/ActionsMenuLayout/dataHooks.ts
+++ b/src/components/ActionsMenuLayout/dataHooks.ts
@@ -3,3 +3,5 @@ export enum ACTIONS_MENU_DATA_KEYS {
 }
 
 export const ACTIONS_MENU_ITEM_DATA_HOOK = 'actions-menu-item';
+
+export const ACTIONS_MENU_E2E_DATA_HOOK = 'storybook-e2e-actions-menu';

--- a/src/components/ActionsMenuLayout/docs/ActionsMenuLayoutTestStory.tsx
+++ b/src/components/ActionsMenuLayout/docs/ActionsMenuLayoutTestStory.tsx
@@ -1,0 +1,41 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { ActionsMenuLayout } from '..';
+import { StoryCategory } from '../../../../stories/storyHierarchy';
+import { ACTIONS_MENU_E2E_DATA_HOOK } from '../dataHooks';
+
+function ActionsMenuLayoutTest() {
+  return (
+    <div>
+      <ActionsMenuLayout
+        focusedIndex={1}
+        data-hook={ACTIONS_MENU_E2E_DATA_HOOK}
+      >
+        <ActionsMenuLayout.Item onClick={() => {}} content="item 1" />
+        <ActionsMenuLayout.Item
+          onClick={() => {}}
+          content="item 2"
+          subtitle="Subtitle"
+        />
+        <ActionsMenuLayout.Divider />
+        <ActionsMenuLayout.Item
+          onClick={() => {}}
+          content="item 3"
+          subtitle="Subtitle"
+        />
+        <ActionsMenuLayout.Item
+          onClick={() => {}}
+          content="item 4"
+          subtitle="Subtitle"
+          disabled
+        />
+        <ActionsMenuLayout.Item onClick={() => {}} content="item 5" />
+      </ActionsMenuLayout>
+    </div>
+  );
+}
+
+storiesOf(StoryCategory.TESTS, module).add(
+  'ActionsMenuLayout',
+  ActionsMenuLayoutTest,
+);

--- a/stories/testStories.ts
+++ b/stories/testStories.ts
@@ -7,3 +7,4 @@ require('../src/components/Ratings/docs/RatingsTestStory');
 require('../src/components/Tabs/docs/TabsTestStory');
 require('../src/components/TextArea/docs/TextAreaTestStory');
 require('../src/components/Tooltip/docs/TooltipTestStory');
+require('../src/components/ActionsMenuLayout/docs/ActionsMenuLayoutTestStory');


### PR DESCRIPTION
<!--
  Thanks for creating a pull request to `wix-ui-tpa`!

  =========================
   Before creating the PR:
  =========================
  
    - Please make sure your commits are signed,the PR cannot be merged without it.
      Read more about it here:
      https://github.com/wix/wix-style-react/blob/master/docs/contribution/CREATE_PR.md#sign-commits
      
    - If the PR changes/adds something to the UI, make sure it's aligned to the design system specs:
      https://zeroheight.com/7sjjzhgo2/p/7181b5-tpa-design-system
      
  -->

# ✨ Pull Request

### 💁 Description
	Fixes https://jira.wixpress.com/browse/DSM-1138
	
	Currently component always focuses the first element or the one provided with focusedIndex prop on initial load, which is problematic in some use-cases.
Update behaviour will only autofocus if focusedIndex prop is provided. Manual focus is affected by this change - tab focus, arrow key navigation and focus on click are not affected.
Also fixed bug where clicking on list item would not always update internal state, so trying to use arrow keys would focus on the wrong list item.

...

### 💭 Motivation

<!---
  Why is this solution right for the issue/task?
  If infra task - how will this make our life better?
  e.g 
  "- Will reduce bundle size by X"
  ...
  -->

...


### ☝️ TODOs <!-- optional -->

<!---
  List leftover tasks, related PR's blocking this etc...
  e.g
  "- [ ] waiting for PR merge in wix-ui-core"
  ...
  -->
...

### 👀  PR is ready for review 

<!-- mark checkbox to let reviewers know you're ready -->

- [x] Ready for review
