### PR TITLE
Image - fix flaky tests

### DIFF
--- a/src/components/Image/Image.visual.st.css
+++ b/src/components/Image/Image.visual.st.css
@@ -5,7 +5,7 @@
 }
 
 .backgroundColorOverride {
-  -st-mixin: overrideStyleParams(BackgroundColor 'color-5');
+  -st-mixin: overrideStyleParams(BackgroundColor 'color-5', ImageOpacity '0%');
 }
 
 .borderOverride {

--- a/src/components/Image/Image.visual.tsx
+++ b/src/components/Image/Image.visual.tsx
@@ -31,8 +31,10 @@ class ImageWithWrapper extends React.Component<ImageWithWrapperProps> {
   state = { hasError: false };
 
   async onError(onError) {
-    this.setState({ hasError: true }, () => () => onError());
-    await delay(500);
+    this.setState({ hasError: true }, async () => {
+      await delay(500);
+      onError();
+    });
   }
 
   render() {

--- a/src/components/Image/Image.visual.tsx
+++ b/src/components/Image/Image.visual.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { delay } from '../../test/utils';
 import { snap, story, visualize } from 'storybook-snapper';
 import { Image, ImageProps } from './';
 import { classes } from './Image.visual.st.css';
@@ -29,8 +30,9 @@ type ImageWithWrapperProps = ImageProps & {
 class ImageWithWrapper extends React.Component<ImageWithWrapperProps> {
   state = { hasError: false };
 
-  onError(onError) {
-    this.setState({ hasError: true }, () => setTimeout(() => onError(), 500));
+  async onError(onError) {
+    this.setState({ hasError: true }, () => () => onError());
+    await delay(500);
   }
 
   render() {
@@ -164,7 +166,7 @@ visualize('Image', () => {
       story('with wiring', () => {
         snap('override background color', (done) => (
           <ImageWithWrapper
-            src={invalidSrc}
+            src={src}
             width={480}
             height={360}
             className={classes.backgroundColorOverride}

--- a/src/components/Image/Image.visual.tsx
+++ b/src/components/Image/Image.visual.tsx
@@ -30,7 +30,7 @@ type ImageWithWrapperProps = ImageProps & {
 class ImageWithWrapper extends React.Component<ImageWithWrapperProps> {
   state = { hasError: false };
 
-  async onError(onError) {
+  async _onError(onError) {
     this.setState({ hasError: true }, async () => {
       await delay(500);
       onError();
@@ -49,7 +49,7 @@ class ImageWithWrapper extends React.Component<ImageWithWrapperProps> {
 
     return (
       <div style={style}>
-        <Image {...imageProps} onError={() => this.onError(onError)} />
+        <Image {...imageProps} onError={() => this._onError(onError)} />
       </div>
     );
   }


### PR DESCRIPTION
<!--
  Thanks for creating a pull request to `wix-ui-tpa`!

  =========================
   Before creating the PR:
  =========================
  
    - Please make sure your commits are signed,the PR cannot be merged without it.
      Read more about it here:
      https://github.com/wix/wix-style-react/blob/master/docs/contribution/CREATE_PR.md#sign-commits
      
    - If the PR changes/adds something to the UI, make sure it's aligned to the design system specs:
      https://zeroheight.com/7sjjzhgo2/p/7181b5-tpa-design-system
      
  -->

# ✨ Pull Request

### 💁 Description

This PR should fix the flaky tests in Image.

Those are the problematic tests:
- Image/Relative Media URI/with wiring: override background color
- Image/Absolute URL/with wiring: override background color
- Image/Relative Media URI: with onError
- Image/Relative Media URI: with onError

The common for all of them is the usage of `invalidSrc` which triggers the native broken image icon of the browser. The thing is ui-core's Image [replaces](https://github.com/wix/wix-ui/blob/master/packages/wix-ui-core/src/components/image/image.tsx#L113-L116) the source in such cases with an image with dimensions of 1x1 pixels, in order to hide the native icon. Probably sometimes Applitools is fast enough to take the screenshot before that the icon is replaced (I also managed to notice it when running the visuals locally).

I believe the 500ms with `await` should fix the problem because `onError` is invoked in ui-core's Image after setting the state (inside ui-core's Image). In case of the "override background color" I changed it to a non-broken source and simply hide the image to show the wired background.

### 👀  PR is ready for review 

<!-- mark checkbox to let reviewers know you're ready -->

- [X] Ready for review
